### PR TITLE
Keep chat input always visible and improve styling

### DIFF
--- a/frontend/app/chat/[sessionId]/components/ChatInput.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatInput.tsx
@@ -21,7 +21,6 @@ interface ChatInputProps {
   isLoadingHistory: boolean;
   canSend: boolean;
   agentName: string;
-  isVisible: boolean;
 }
 
 export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(({
@@ -40,17 +39,13 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(({
   isLoadingHistory,
   canSend,
   agentName,
-  isVisible,
 }, textareaRef) => {
   const imageInputRef = useRef<HTMLInputElement>(null);
 
   return (
-      <div className={cn(
-        "absolute bottom-0 left-0 w-full md:pl-[260px] bg-gradient-to-t from-background via-background/95 to-transparent pt-4 sm:pt-6 pb-3 sm:pb-4 transition-transform duration-300 ease-in-out",
-        !isVisible && "translate-y-full"
-      )}>
-      <div className="max-w-4xl mx-auto px-3 sm:px-4 md:px-6">
-        <div className="relative flex flex-col w-full bg-white/95 dark:bg-zinc-950/70 backdrop-blur-xl rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 shadow-[0_8px_30px_rgba(15,23,42,0.08)] dark:shadow-[0_8px_30px_rgba(0,0,0,0.45)] transition-all duration-300 overflow-hidden">
+      <div className="absolute bottom-0 left-0 w-full md:pl-[260px] bg-gradient-to-t from-background via-background/95 to-transparent pt-3 sm:pt-4 pb-2 sm:pb-3">
+      <div className="max-w-5xl mx-auto px-3 sm:px-4 md:px-6">
+        <div className="relative flex flex-col w-full bg-white/95 dark:bg-zinc-950/70 backdrop-blur-xl rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 shadow-[0_4px_20px_rgba(15,23,42,0.06)] dark:shadow-[0_4px_20px_rgba(0,0,0,0.35)] transition-all duration-300 overflow-hidden">
           {selectedImages.length > 0 && (
             <div className="flex flex-wrap gap-2 px-3 pt-3">
               {selectedImages.map((image, index) => (
@@ -112,7 +107,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(({
               onPaste={onPaste}
               onFocus={onFocus}
               placeholder={isLoadingHistory ? "正在加载历史记录..." : `给 ${agentName} 发送消息`}
-              className="chat-input-textarea flex-1 min-h-[44px] max-h-[160px] rounded-xl border border-zinc-200/80 dark:border-zinc-800/80 bg-zinc-50/70 dark:bg-zinc-900/40 shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] focus-visible:border-zinc-400/80 dark:focus-visible:border-zinc-600/80 focus-visible:ring-2 focus-visible:ring-zinc-300/60 dark:focus-visible:ring-zinc-700/60 px-3.5 py-3 text-base sm:text-sm overflow-y-auto resize-none placeholder:text-zinc-500/70 dark:placeholder:text-zinc-400/60 no-scrollbar leading-relaxed transition-colors"
+              className="chat-input-textarea flex-1 min-h-[44px] max-h-[160px] rounded-xl border-0 bg-transparent shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 px-2.5 py-2 text-sm overflow-y-auto resize-none placeholder:text-zinc-400/70 dark:placeholder:text-zinc-500/60 no-scrollbar leading-normal transition-colors"
               disabled={isLoading || isLoadingHistory}
               autoComplete="off"
               rows={1}

--- a/frontend/app/chat/[sessionId]/page.tsx
+++ b/frontend/app/chat/[sessionId]/page.tsx
@@ -11,7 +11,7 @@ import { cn } from '@/app/lib/utils';
 
 // 导入类型和常量
 import type { Message, SelectedImage } from './types';
-import { agentInfoMap, MESSAGES_PER_PAGE, LOAD_MORE_THRESHOLD, MIN_SCROLL_THRESHOLD, MIN_SCROLL_DISTANCE, SCROLL_RESET_DELAY } from './constants';
+import { agentInfoMap, MESSAGES_PER_PAGE, LOAD_MORE_THRESHOLD, SCROLL_RESET_DELAY } from './constants';
 
 // 导入组件
 import { AIAvatar, UserAvatar, ChatSkeleton, AIMessageContent, UserMessage, ChatInput } from './components';
@@ -40,7 +40,6 @@ export default function ChatPage() {
   const [isSessionsLoading, setIsSessionsLoading] = useState(false);
   const [shouldScrollInstantly, setShouldScrollInstantly] = useState(false);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
-  const [isInputVisible, setIsInputVisible] = useState(true);
   const [copiedUserMessageId, setCopiedUserMessageId] = useState<string | null>(null);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState('');
@@ -66,7 +65,6 @@ export default function ChatPage() {
   const previousScrollHeightRef = useRef<number>(0);
   const isAtBottomRef = useRef(true);
   const lastScrollTopRef = useRef(0);
-  const scrollDirectionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copiedUserMessageTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // 会话管理
@@ -108,7 +106,6 @@ export default function ChatPage() {
     setTotalMessageCount(0);
     setIsLoadingHistory(true);
     setShouldScrollInstantly(true);
-    setIsInputVisible(true);
     clearImages();
     setEditingMessageId(null);
     setEditingValue('');
@@ -201,7 +198,6 @@ export default function ChatPage() {
     setMessages([]);
     setHasMoreMessages(false);
     setTotalMessageCount(0);
-    setIsInputVisible(true);
     setInputValue('');
     clearImages();
     setTimeout(() => {
@@ -259,28 +255,6 @@ export default function ChatPage() {
         loadOlderMessages();
       }
 
-      const scrollDelta = scrollTop - lastScrollTopRef.current;
-
-      if (atBottom) {
-        setIsInputVisible(true);
-        lastScrollTopRef.current = scrollTop;
-        return;
-      }
-
-      if (Math.abs(scrollDelta) > MIN_SCROLL_THRESHOLD && scrollTop > MIN_SCROLL_DISTANCE) {
-        if (scrollDirectionTimeoutRef.current) {
-          clearTimeout(scrollDirectionTimeoutRef.current);
-        }
-
-        if (scrollDelta < 0) {
-          setIsInputVisible(false);
-        } else if (scrollDelta > 0) {
-          scrollDirectionTimeoutRef.current = setTimeout(() => {
-            setIsInputVisible(true);
-          }, 100);
-        }
-      }
-
       lastScrollTopRef.current = scrollTop;
     }
   };
@@ -294,30 +268,20 @@ export default function ChatPage() {
         behavior: shouldScrollInstantly ? 'auto' : 'smooth'
       });
     }
-
-    if (isNewUserMessage) {
-      setIsInputVisible(true);
-    }
   }, [messages, shouldScrollInstantly]);
 
-  // 空会话时显示输入框
+  // 空会话时聚焦输入框
   useEffect(() => {
     if (messages.length === 0 && !isLoadingHistory) {
-      if (!isInputVisible) {
-        setIsInputVisible(true);
-      }
       textareaRef.current?.focus();
     }
-  }, [messages.length, isLoadingHistory, isInputVisible]);
+  }, [messages.length, isLoadingHistory]);
 
   // 清理超时
   useEffect(() => {
     return () => {
       if (scrollResetTimeoutRef.current) {
         clearTimeout(scrollResetTimeoutRef.current);
-      }
-      if (scrollDirectionTimeoutRef.current) {
-        clearTimeout(scrollDirectionTimeoutRef.current);
       }
       if (copiedUserMessageTimeoutRef.current) {
         clearTimeout(copiedUserMessageTimeoutRef.current);
@@ -1021,7 +985,7 @@ export default function ChatPage() {
           onPaste={handlePaste}
           onSubmit={handleSubmit}
           onCancel={handleCancelMessage}
-          onFocus={() => setIsInputVisible(true)}
+          onFocus={() => {}}
           selectedImages={selectedImages}
           onRemoveImage={handleRemoveImage}
           onImageSelect={handleImageSelect}
@@ -1030,7 +994,6 @@ export default function ChatPage() {
           isLoadingHistory={isLoadingHistory}
           canSend={canSend}
           agentName={agentInfo.name}
-          isVisible={isInputVisible}
         />
       </div>
     </div>


### PR DESCRIPTION
## Changes

- **Always-visible input**: Removed scroll-direction-based hide/show behavior so the chat input box stays fixed at the bottom at all times
- **Cleaner look**: Removed inner textarea border, using only the outer card border for a single-border design
- **Wider input**: Increased container max-width from `max-w-4xl` (896px) to `max-w-5xl` (1024px)
- **Cleanup**: Removed unused `isInputVisible` state, scroll direction detection logic, and related refs/constants

Closes #143