### PR TITLE
fix: enable thinking on planner and executor agents

### DIFF
--- a/internal/app/aiguide/assistant/executor_agent.go
+++ b/internal/app/aiguide/assistant/executor_agent.go
@@ -88,6 +88,11 @@ func NewExecutorAgent(config *ExecutorAgentConfig) (agent.Agent, error) {
 		Name:        "executor",
 		Description: "Specialized agent for executing tasks using tools like image generation, email queries, web search, and web fetching",
 		Model:       config.Model,
+		GenerateContentConfig: &genai.GenerateContentConfig{
+			ThinkingConfig: &genai.ThinkingConfig{
+				IncludeThoughts: true,
+			},
+		},
 		Tools: []tool.Tool{
 			// 功能工具
 			currentTimeTool, // Get current date/time - use before web_search for time-sensitive queries

--- a/internal/app/aiguide/assistant/planner_agent.go
+++ b/internal/app/aiguide/assistant/planner_agent.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/adk/agent/llmagent"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/tool"
+	"google.golang.org/genai"
 	"gorm.io/gorm"
 
 	"aiguide/internal/pkg/tools"
@@ -62,6 +63,11 @@ func NewPlannerAgent(config *PlannerAgentConfig) (agent.Agent, error) {
 		Name:        "planner",
 		Description: "Specialized agent for breaking down complex tasks into structured plans with subtasks, dependencies, and priorities",
 		Model:       config.Model,
+		GenerateContentConfig: &genai.GenerateContentConfig{
+			ThinkingConfig: &genai.ThinkingConfig{
+				IncludeThoughts: true,
+			},
+		},
 		Tools: []tool.Tool{
 			taskCreateTool,
 			taskUpdateTool,


### PR DESCRIPTION
## Summary
- enable Gemini thinking output on the planner and executor sub-agents
- align sub-agent generation config with the root agent so thought parts can flow through the existing SSE/UI pipeline