### PR TITLE
fix: preserve inline math expressions that start with digits

### DIFF
--- a/frontend/app/chat/[sessionId]/utils/markdown.tsx
+++ b/frontend/app/chat/[sessionId]/utils/markdown.tsx
@@ -15,13 +15,15 @@ import { cn } from '@/app/lib/utils';
 // Preprocess markdown to escape currency dollar signs (e.g. `$100`) before remark-math parses them.
 export const markdownRemarkPlugins: PluggableList = [remarkGfm, remarkBreaks, remarkMath];
 
+const currencyPattern = /(?<!\\)\$(\d+(?:,\d{3})*(?:\.\d+)?)(?=$|[\s),.?!:;%\]])/g;
+
 /**
- * Escapes dollar signs that look like currency amounts (followed by a digit),
+ * Escapes dollar signs that look like standalone currency amounts,
  * preventing remark-math from treating them as LaTeX delimiters.
- * e.g. "$100" → "\$100", but "$T$" remains unchanged.
+ * e.g. "$100" -> "\$100", but "$2^{30} \approx 10^9$" remains unchanged.
  */
 export function preprocessMarkdown(content: string): string {
-  return content.replace(/\$(?=\d)/g, '\\$');
+  return content.replace(currencyPattern, '\\$$1');
 }
 export const markdownRehypePlugins: PluggableList = [rehypeKatex];
 


### PR DESCRIPTION
## Summary
- narrow markdown preprocessing so only standalone currency amounts like `$100` are escaped before math parsing
- preserve inline LaTeX expressions that begin with digits, such as `$2^{30} \approx 10^9$`
- keep existing KaTeX rendering flow unchanged for chat messages

## Validation
- ran `pnpm lint` in `frontend/` and confirmed the repo still has pre-existing lint errors unrelated to this change
- ran `pnpm eslint \"app/chat/[sessionId]/utils/markdown.tsx\"` and got warnings only, with no errors in the modified file