### PR TITLE
feat: stream tool call progress to frontend

### DIFF
--- a/frontend/app/chat/[sessionId]/components/MessageContent.tsx
+++ b/frontend/app/chat/[sessionId]/components/MessageContent.tsx
@@ -5,6 +5,7 @@ import { Code2, Eye, Copy, Check, X, ChevronDown, ChevronRight, RotateCcw } from
 import { cn } from '@/app/lib/utils';
 import { markdownRemarkPlugins, markdownRehypePlugins, markdownComponents, preprocessMarkdown } from '../utils/markdown';
 import { FEEDBACK_TIMEOUT_MS } from '../constants';
+import type { ToolCallItem } from '../types';
 
 interface AIMessageContentProps {
   content: string;
@@ -14,6 +15,7 @@ interface AIMessageContentProps {
   isError?: boolean;
   onRetry?: () => void;
   thoughtStorageKey?: string;
+  toolCalls?: ToolCallItem[];
 }
 
 export const AIMessageContent = memo(({
@@ -23,7 +25,8 @@ export const AIMessageContent = memo(({
   images,
   isError,
   onRetry,
-  thoughtStorageKey
+  thoughtStorageKey,
+  toolCalls,
 }: AIMessageContentProps) => {
   const [showRaw, setShowRaw] = useState(false);
   const [isThoughtExpanded, setIsThoughtExpanded] = useState(() => {
@@ -126,6 +129,29 @@ export const AIMessageContent = memo(({
               )}
             </div>
           </div>
+        </div>
+      )}
+
+      {/* Tool calls section */}
+      {toolCalls && toolCalls.length > 0 && (
+        <div className="mb-3 flex flex-col gap-1.5">
+          {toolCalls.map((tc, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/40 border border-muted-foreground/10 px-3 py-1.5 rounded-md w-fit"
+            >
+              {isStreaming && i === toolCalls.length - 1 ? (
+                <div className="flex space-x-0.5">
+                  <div className="w-1 h-1 bg-primary/60 rounded-full animate-bounce [animation-delay:-0.3s]" />
+                  <div className="w-1 h-1 bg-primary/60 rounded-full animate-bounce [animation-delay:-0.15s]" />
+                  <div className="w-1 h-1 bg-primary/60 rounded-full animate-bounce" />
+                </div>
+              ) : (
+                <div className="w-1 h-1 bg-muted-foreground/40 rounded-full" />
+              )}
+              <span>{tc.label}</span>
+            </div>
+          ))}
         </div>
       )}
 

--- a/frontend/app/chat/[sessionId]/page.tsx
+++ b/frontend/app/chat/[sessionId]/page.tsx
@@ -10,7 +10,7 @@ import { Check, Copy, Menu, Pencil, X, Share2 } from 'lucide-react';
 import { cn } from '@/app/lib/utils';
 
 // 导入类型和常量
-import type { Message, SelectedImage } from './types';
+import type { Message, SelectedImage, ToolCallItem } from './types';
 import { agentInfoMap, MESSAGES_PER_PAGE, LOAD_MORE_THRESHOLD, SCROLL_RESET_DELAY } from './constants';
 
 // 导入组件
@@ -824,6 +824,34 @@ export default function ChatPage() {
                   continue;
                 }
 
+                if (currentEventType === 'tool_call') {
+                  const toolCall = { toolName: data.tool_name as string, label: data.tool_label as string };
+                  setMessages((prev) => {
+                    const newMessages = [...prev];
+                    const lastIndex = newMessages.length - 1;
+                    if (lastIndex >= 0 && newMessages[lastIndex].role === 'assistant') {
+                      newMessages[lastIndex] = {
+                        ...newMessages[lastIndex],
+                        toolCalls: [...(newMessages[lastIndex].toolCalls || []), toolCall],
+                        isStreaming: true,
+                      };
+                    } else {
+                      newMessages.push({
+                        id: `msg-${Date.now()}-${data.author || 'assistant'}`,
+                        role: 'assistant',
+                        content: '',
+                        timestamp: new Date(),
+                        author: data.author as string,
+                        isStreaming: true,
+                        toolCalls: [toolCall],
+                      });
+                    }
+                    return newMessages;
+                  });
+                  currentEventType = 'data';
+                  continue;
+                }
+
                 if (data.images && Array.isArray(data.images)) {
                   assistantImages = [...assistantImages, ...data.images];
 
@@ -1109,6 +1137,7 @@ export default function ChatPage() {
                               images={message.images}
                               isError={message.isError}
                               onRetry={() => sendMessage("", [])}
+                              toolCalls={message.toolCalls}
                             />
                           </div>
                         ) : (

--- a/frontend/app/chat/[sessionId]/types.ts
+++ b/frontend/app/chat/[sessionId]/types.ts
@@ -1,3 +1,8 @@
+export interface ToolCallItem {
+  toolName: string;
+  label: string;
+}
+
 export interface Message {
   id: string;
   role: 'user' | 'assistant';
@@ -9,6 +14,7 @@ export interface Message {
   images?: string[];
   fileNames?: string[]; // 文件名列表，与 images 对应
   isError?: boolean;
+  toolCalls?: ToolCallItem[];
 }
 
 export interface SelectedImage {

--- a/internal/app/aiguide/assistant/sse.go
+++ b/internal/app/aiguide/assistant/sse.go
@@ -362,6 +362,18 @@ func (a *Assistant) streamAgentEvents(
 					ctx.Writer.Flush()
 				}
 
+				// 处理 FunctionCall（工具调用），发送给前端展示进度
+				if part.FunctionCall != nil {
+					label := toolCallLabel(part.FunctionCall.Name, part.FunctionCall.Args)
+					data := gin.H{
+						"author":     event.Author,
+						"tool_name":  part.FunctionCall.Name,
+						"tool_label": label,
+					}
+					ctx.SSEvent("tool_call", data)
+					ctx.Writer.Flush()
+				}
+
 				// 处理 FunctionResponse 中的图片数据
 				if part.FunctionResponse != nil {
 					response := part.FunctionResponse.Response
@@ -468,6 +480,53 @@ func prependMemoryContext(parts []*genai.Part, memoryContext string) []*genai.Pa
 	}
 	// 没有文本 part 时，在最前面插入一个文本 part
 	return append([]*genai.Part{genai.NewPartFromText(memoryContext)}, parts...)
+}
+
+// toolCallLabel 将工具调用转换为用户可读的进度描述
+func toolCallLabel(name string, args map[string]any) string {
+	switch name {
+	case "task_create":
+		if title, ok := args["title"].(string); ok {
+			return fmt.Sprintf("正在创建任务：%s", title)
+		}
+		return "正在创建任务"
+	case "task_update":
+		if id, ok := args["task_id"]; ok {
+			return fmt.Sprintf("正在更新任务 #%v", id)
+		}
+		return "正在更新任务"
+	case "task_list":
+		return "正在检查任务列表"
+	case "task_get":
+		return "正在获取任务详情"
+	case "finish_planning":
+		return "规划完成，准备执行"
+	case "web_search":
+		if query, ok := args["query"].(string); ok {
+			return fmt.Sprintf("正在搜索：%s", query)
+		}
+		return "正在搜索"
+	case "exa_search":
+		if query, ok := args["query"].(string); ok {
+			return fmt.Sprintf("正在语义搜索：%s", query)
+		}
+		return "正在语义搜索"
+	case "web_fetch":
+		if url, ok := args["url"].(string); ok {
+			return fmt.Sprintf("正在获取网页：%s", url)
+		}
+		return "正在获取网页"
+	case "image_gen":
+		return "正在生成图片"
+	case "email_query":
+		return "正在查询邮件"
+	case "current_time":
+		return "正在获取当前时间"
+	case "manage_memory":
+		return "正在管理记忆"
+	default:
+		return fmt.Sprintf("调用 %s", name)
+	}
 }
 
 // generateTitle 生成会话标题


### PR DESCRIPTION
## Summary

- **后端** (`sse.go`)：在 SSE 事件循环中检测 `FunctionCall` parts，为每个工具调用推送新的 `tool_call` 事件，包含人类可读的进度描述（如"正在创建任务：分析交通方案"、"正在搜索：..."）
- **前端** (`types.ts`)：新增 `ToolCallItem` 类型，`Message` 类型加 `toolCalls` 字段
- **前端** (`page.tsx`)：处理 `tool_call` SSE 事件，追加到当前流式消息的 toolCalls 列表
- **前端** (`MessageContent.tsx`)：将 tool calls 渲染为状态 pill，最新一个在 streaming 时显示跳动动画

## 效果

用户在 planner 规划、executor 执行期间可以实时看到每一步的进度，而不是界面上一片空白。

## Test plan

- [ ] 触发旅游规划类请求，观察规划阶段是否出现任务创建进度 pill
- [ ] 触发搜索类请求，观察 executor 执行时是否出现搜索进度 pill
- [ ] 流式结束后，pill 的跳动动画停止，保留历史记录