### PR TITLE
fix: prevent long user messages from breaking chat layout

### DIFF
--- a/frontend/app/chat/[sessionId]/components/UserMessage.tsx
+++ b/frontend/app/chat/[sessionId]/components/UserMessage.tsx
@@ -38,7 +38,7 @@ export function UserMessage({ content, images, fileNames }: UserMessageProps) {
         </div>
       )}
       {content && (
-        <div className="prose prose-sm prose-zinc dark:prose-invert max-w-none prose-p:leading-relaxed prose-p:my-3 prose-pre:p-0 prose-pre:rounded-lg prose-headings:my-4 prose-headings:font-semibold break-words [overflow-wrap:anywhere]">
+        <div className="prose prose-sm prose-zinc dark:prose-invert max-w-none min-w-0 prose-p:my-3 prose-p:leading-relaxed prose-pre:p-0 prose-pre:rounded-lg prose-headings:my-4 prose-headings:font-semibold break-words break-all [overflow-wrap:anywhere]">
           <ReactMarkdown
             remarkPlugins={markdownRemarkPlugins}
             rehypePlugins={markdownRehypePlugins}

--- a/frontend/app/chat/[sessionId]/page.tsx
+++ b/frontend/app/chat/[sessionId]/page.tsx
@@ -1142,7 +1142,7 @@ export default function ChatPage() {
                           </div>
                         ) : (
                           <div className="relative flex flex-col items-end">
-                            <div className="relative text-sm leading-relaxed bg-zinc-100 dark:bg-zinc-800 px-4 py-2.5 rounded-2xl rounded-tr-sm w-fit max-w-full min-w-[180px]">
+                            <div className="relative w-full min-w-0 max-w-full overflow-hidden rounded-2xl rounded-tr-sm bg-zinc-100 px-4 py-2.5 text-sm leading-relaxed dark:bg-zinc-800 sm:min-w-[180px] sm:w-fit">
                               {editingMessageId === message.id ? (
                                 <div className="space-y-2">
                                   {(message.images?.length || 0) > 0 && (

--- a/frontend/app/share/[shareId]/page.tsx
+++ b/frontend/app/share/[shareId]/page.tsx
@@ -268,7 +268,7 @@ export default function SharedConversationPage() {
                           </div>
                         ) : (
                           <div className="relative flex flex-col items-end">
-                            <div className="relative text-sm leading-relaxed bg-zinc-100 dark:bg-zinc-800 px-4 py-2.5 rounded-2xl rounded-tr-sm max-w-fit min-w-[180px]">
+                            <div className="relative w-full min-w-0 max-w-full overflow-hidden rounded-2xl rounded-tr-sm bg-zinc-100 px-4 py-2.5 text-sm leading-relaxed dark:bg-zinc-800 sm:min-w-[180px] sm:w-fit">
                               <UserMessage
                                 content={message.content}
                                 images={message.images}


### PR DESCRIPTION
## Summary
- constrain user message bubbles so long text cannot stretch the chat layout on smaller screens
- add stronger wrapping rules for long user-entered text without spaces
- apply the same layout fix to the shared conversation page for consistency