### PR TITLE
fix: preserve inline latex math rendering

### DIFF
--- a/frontend/app/chat/[sessionId]/utils/markdown.tsx
+++ b/frontend/app/chat/[sessionId]/utils/markdown.tsx
@@ -15,7 +15,7 @@ import { cn } from '@/app/lib/utils';
 // Preprocess markdown to escape currency dollar signs (e.g. `$100`) before remark-math parses them.
 export const markdownRemarkPlugins: PluggableList = [remarkGfm, remarkBreaks, remarkMath];
 
-const currencyPattern = /(?<!\\)\$(\d+(?:,\d{3})*(?:\.\d+)?)(?=$|[\s),.?!:;%\]])/g;
+const currencyPattern = /(?<!\\)\$(\d+(?:,\d{3})*(?:\.\d+)?)(?=$|[\s),?!:;%\]]|\.(?!\d))/g;
 
 /**
  * Escapes dollar signs that look like standalone currency amounts,


### PR DESCRIPTION
## Summary
- tighten markdown currency detection so decimal-valued inline LaTeX is not escaped as plain currency
- restore correct rendering for formulas like `$1.5\text{ cm} \times 3.5\text{ cm}$` in chat messages
- keep the existing protection for plain dollar amounts such as `$100`