### PR TITLE
feat: add memory management API and frontend memory center

### DIFF
--- a/frontend/app/components/SessionSidebar.tsx
+++ b/frontend/app/components/SessionSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, memo, useEffect } from 'react';
 import { Button } from '@/app/components/ui/button';
-import { Plus, ChevronLeft, ChevronRight, Trash2, LogOut, FolderOpen, MoreHorizontal, Pencil } from 'lucide-react';
+import { Plus, ChevronLeft, ChevronRight, Trash2, LogOut, FolderOpen, MoreHorizontal, Pencil, Brain } from 'lucide-react';
 import { cn } from '@/app/lib/utils';
 import { useAuth } from '@/app/contexts/AuthContext';
 import { Avatar, AvatarFallback, AvatarImage } from '@/app/components/ui/avatar';
@@ -77,19 +77,20 @@ const SessionSidebar = memo(({
   const { user, logout } = useAuth();
   const [isCollapsed, setIsCollapsed] = useState(false);
 
-  const matchesProjectFilter = (session: Session) => {
-    if (activeProjectId === 'all') {
-      return true;
-    }
-    if (activeProjectId === 'none') {
-      return (session.project_id ?? 0) === 0;
-    }
-
-    return String(session.project_id ?? 0) === activeProjectId;
-  };
-
   const filteredSessions = useMemo(() => {
-    const sessionWithContent = sessions.filter((s) => (s.title || s.first_message) && matchesProjectFilter(s));
+    const sessionWithContent = sessions.filter((session) => {
+      if (!session.title && !session.first_message) {
+        return false;
+      }
+      if (activeProjectId === 'all') {
+        return true;
+      }
+      if (activeProjectId === 'none') {
+        return (session.project_id ?? 0) === 0;
+      }
+
+      return String(session.project_id ?? 0) === activeProjectId;
+    });
     const byThread = new Map<string, Session>();
 
     sessionWithContent.forEach((session) => {
@@ -467,6 +468,18 @@ const SessionSidebar = memo(({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" side="top" className="w-56 bg-zinc-900 border-zinc-800 text-zinc-100">
+                <DropdownMenuItem
+                  className="cursor-pointer"
+                  onClick={() => {
+                    if (typeof window !== 'undefined') {
+                      window.location.href = '/memory';
+                    }
+                  }}
+                >
+                  <Brain className="mr-2 h-4 w-4" />
+                  <span>记忆中心</span>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
                 <DropdownMenuItem
                   className="text-red-400 focus:text-red-400 focus:bg-red-900/20 cursor-pointer"
                   onClick={logout}

--- a/frontend/app/memory/MemoryEditorModal.tsx
+++ b/frontend/app/memory/MemoryEditorModal.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import type { FormEvent } from 'react';
+import { useEffect } from 'react';
+import { Plus, X } from 'lucide-react';
+import { Button } from '@/app/components/ui/button';
+import { Textarea } from '@/app/components/ui/textarea';
+import { cn } from '@/app/lib/utils';
+
+type MemoryType = 'fact' | 'preference' | 'context';
+
+interface MemoryFormData {
+  memory_type: MemoryType;
+  content: string;
+  importance: number;
+}
+
+interface MemoryEditorModalProps {
+  isOpen: boolean;
+  editingMemoryId: number | null;
+  formData: MemoryFormData;
+  isSubmitting: boolean;
+  onClose: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
+  onChange: (next: MemoryFormData) => void;
+}
+
+const filters: Array<{ value: MemoryType; label: string }> = [
+  { value: 'fact', label: '事实' },
+  { value: 'preference', label: '偏好' },
+  { value: 'context', label: '上下文' },
+];
+
+export function MemoryEditorModal({
+  isOpen,
+  editingMemoryId,
+  formData,
+  isSubmitting,
+  onClose,
+  onSubmit,
+  onChange,
+}: MemoryEditorModalProps) {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !isSubmitting) {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, isSubmitting, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+      <div
+        className="absolute inset-0"
+        onClick={() => {
+          if (!isSubmitting) {
+            onClose();
+          }
+        }}
+      />
+
+      <div className="relative w-full max-w-xl rounded-2xl border border-zinc-800 bg-zinc-900 text-zinc-100 shadow-2xl">
+        <div className="flex items-start justify-between gap-4 border-b border-zinc-800 px-5 py-4">
+          <div>
+            <h2 className="text-lg font-semibold text-white">{editingMemoryId ? '编辑记忆' : '新增记忆'}</h2>
+            <p className="mt-1 text-sm text-zinc-400">保留会长期影响回答质量的信息，尽量简洁明确。</p>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="h-8 w-8 rounded-full text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+            aria-label="关闭记忆编辑弹窗"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <form onSubmit={onSubmit} className="space-y-5 px-5 py-5">
+          <div className="grid gap-2">
+            <div className="text-sm font-medium text-zinc-200">记忆类型</div>
+            <div className="grid grid-cols-3 gap-2">
+              {filters.map((filter) => {
+                const active = formData.memory_type === filter.value;
+                return (
+                  <button
+                    key={filter.value}
+                    type="button"
+                    onClick={() => onChange({ ...formData, memory_type: filter.value })}
+                    className={cn(
+                      'rounded-lg border px-3 py-2 text-sm transition',
+                      active
+                        ? 'border-zinc-100 bg-zinc-100 text-zinc-950'
+                        : 'border-zinc-800 bg-zinc-950 text-zinc-300 hover:border-zinc-700 hover:text-zinc-100'
+                    )}
+                  >
+                    {filter.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <label htmlFor="memory-content" className="text-sm font-medium text-zinc-200">记忆内容</label>
+            <Textarea
+              id="memory-content"
+              value={formData.content}
+              onChange={(event) => onChange({ ...formData, content: event.target.value })}
+              placeholder="例如：我更喜欢回答直接一点，代码示例尽量用 Go。"
+              maxLength={2000}
+              className="min-h-[180px] rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-zinc-100 placeholder:text-zinc-500"
+            />
+            <div className="text-right text-xs text-zinc-500">{formData.content.length}/2000</div>
+          </div>
+
+          <div className="grid gap-2">
+            <label htmlFor="memory-importance" className="text-sm font-medium text-zinc-200">重要度 {formData.importance}/10</label>
+            <input
+              id="memory-importance"
+              type="range"
+              min={1}
+              max={10}
+              value={formData.importance}
+              onChange={(event) => onChange({ ...formData, importance: Number(event.target.value) })}
+              className="accent-zinc-100"
+            />
+          </div>
+
+          <div className="flex justify-end gap-2 border-t border-zinc-800 pt-4">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
+            >
+              取消
+            </Button>
+            <Button type="submit" disabled={isSubmitting} className="bg-zinc-100 text-zinc-950 hover:bg-zinc-200 disabled:opacity-60">
+              <Plus className="mr-2 h-4 w-4" />
+              {isSubmitting ? '保存中...' : editingMemoryId ? '保存修改' : '添加记忆'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/memory/page.tsx
+++ b/frontend/app/memory/page.tsx
@@ -1,0 +1,401 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/app/contexts/AuthContext';
+import { Button } from '@/app/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/app/components/ui/card';
+import { Alert, AlertDescription } from '@/app/components/ui/alert';
+import { Brain, ChevronLeft, Pencil, Plus, Trash2 } from 'lucide-react';
+import { cn } from '@/app/lib/utils';
+import { MemoryEditorModal } from './MemoryEditorModal';
+
+type MemoryType = 'fact' | 'preference' | 'context';
+
+interface MemoryInfo {
+  id: number;
+  memory_type: MemoryType;
+  content: string;
+  importance: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface MemoryListResponse {
+  memories: MemoryInfo[];
+}
+
+interface MemoryFormData {
+  memory_type: MemoryType;
+  content: string;
+  importance: number;
+}
+
+type ToastType = 'success' | 'error' | 'info';
+
+interface ToastMessage {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+const filters: Array<{ value: 'all' | MemoryType; label: string }> = [
+  { value: 'all', label: '全部' },
+  { value: 'fact', label: '事实' },
+  { value: 'preference', label: '偏好' },
+  { value: 'context', label: '上下文' },
+];
+
+const defaultFormData: MemoryFormData = {
+  memory_type: 'fact',
+  content: '',
+  importance: 5,
+};
+
+function getMemoryTypeLabel(type: MemoryType) {
+  switch (type) {
+    case 'fact':
+      return '事实';
+    case 'preference':
+      return '偏好';
+    case 'context':
+      return '上下文';
+    default:
+      return type;
+  }
+}
+
+function formatDate(value?: string) {
+  if (!value) {
+    return '暂无';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('zh-CN', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+export default function MemoryPage() {
+  const router = useRouter();
+  const { user, loading, authenticatedFetch } = useAuth();
+  const [memories, setMemories] = useState<MemoryInfo[]>([]);
+  const [activeFilter, setActiveFilter] = useState<'all' | MemoryType>('all');
+  const [showForm, setShowForm] = useState(false);
+  const [editingMemoryId, setEditingMemoryId] = useState<number | null>(null);
+  const [formData, setFormData] = useState<MemoryFormData>(defaultFormData);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  const toastIdRef = useRef(0);
+
+  const notify = (message: string, type: ToastType = 'info') => {
+    const id = toastIdRef.current++;
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((toast) => toast.id !== id));
+    }, 3000);
+  };
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push('/login');
+    }
+  }, [loading, router, user]);
+
+  const loadMemories = useCallback(async (keyword: string, type: 'all' | MemoryType) => {
+    const params = new URLSearchParams();
+    params.set('limit', '100');
+    if (type !== 'all') {
+      params.set('type', type);
+    }
+    if (keyword.trim()) {
+      params.set('keyword', keyword.trim());
+    }
+
+    const response = await authenticatedFetch(`/api/assistant/memories?${params.toString()}`);
+    if (!response.ok) {
+      throw new Error('加载记忆列表失败');
+    }
+    const data: MemoryListResponse = await response.json();
+    setMemories(data.memories || []);
+  }, [authenticatedFetch]);
+
+  const refreshData = useCallback(async (keyword: string, type: 'all' | MemoryType) => {
+    setIsLoading(true);
+    setErrorMessage('');
+    try {
+      await loadMemories(keyword, type);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '加载记忆失败');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [loadMemories]);
+
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+    refreshData('', activeFilter);
+  }, [activeFilter, refreshData, user]);
+
+  const resetForm = () => {
+    setFormData(defaultFormData);
+    setEditingMemoryId(null);
+    setShowForm(false);
+  };
+
+  const handleCreateClick = () => {
+    setFormData(defaultFormData);
+    setEditingMemoryId(null);
+    setShowForm(true);
+  };
+
+  const handleEditClick = (memory: MemoryInfo) => {
+    setEditingMemoryId(memory.id);
+    setFormData({
+      memory_type: memory.memory_type,
+      content: memory.content,
+      importance: memory.importance,
+    });
+    setShowForm(true);
+  };
+
+  const handleDelete = async (memory: MemoryInfo) => {
+    if (!confirm(`确定删除这条${getMemoryTypeLabel(memory.memory_type)}记忆吗？`)) {
+      return;
+    }
+
+    try {
+      const response = await authenticatedFetch(`/api/assistant/memories/${memory.id}`, {
+        method: 'DELETE',
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({ error: '删除记忆失败' }));
+        throw new Error(data.error || '删除记忆失败');
+      }
+
+      notify('记忆已删除', 'success');
+      await refreshData('', activeFilter);
+    } catch (error) {
+      notify(error instanceof Error ? error.message : '删除记忆失败', 'error');
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      const payload = {
+        memory_type: formData.memory_type,
+        content: formData.content.trim(),
+        importance: formData.importance,
+      };
+
+      const isEditing = editingMemoryId !== null;
+      const response = await authenticatedFetch(
+        isEditing ? `/api/assistant/memories/${editingMemoryId}` : '/api/assistant/memories',
+        {
+          method: isEditing ? 'PATCH' : 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        }
+      );
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({ error: '保存记忆失败' }));
+        throw new Error(data.error || '保存记忆失败');
+      }
+
+      notify(isEditing ? '记忆已更新' : '记忆已新增', 'success');
+      resetForm();
+      await refreshData('', activeFilter);
+    } catch (error) {
+      notify(error instanceof Error ? error.message : '保存记忆失败', 'error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (loading || !user) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-zinc-950 text-zinc-200">
+        <div className="rounded-full border border-zinc-800 bg-zinc-900 px-4 py-2 text-sm">正在加载记忆中心...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <Link href="/chat" className="mb-3 inline-flex items-center gap-2 text-sm text-zinc-400 transition hover:text-zinc-100">
+              <ChevronLeft className="h-4 w-4" />
+              返回聊天
+            </Link>
+            <div>
+              <h1 className="text-2xl font-semibold tracking-tight text-white">管理记忆</h1>
+              <p className="mt-1 text-sm text-zinc-400">这些内容会帮助助手在后续对话里更了解你。</p>
+            </div>
+          </div>
+
+          <div className="flex gap-3">
+            <Button type="button" onClick={handleCreateClick} className="bg-zinc-100 text-zinc-950 hover:bg-zinc-200">
+              <Plus className="mr-2 h-4 w-4" />
+              新增记忆
+            </Button>
+          </div>
+        </div>
+
+        {errorMessage && (
+          <Alert className="mb-6 border-red-900 bg-red-950/40 text-red-100">
+            <AlertDescription>{errorMessage}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="space-y-4">
+            <Card className="border-zinc-800 bg-zinc-900/55 shadow-none">
+              <CardHeader className="gap-4 pb-4">
+                <div>
+                  <CardTitle className="text-lg text-white">筛选</CardTitle>
+                  <CardDescription className="text-zinc-500">按类型查看不同类别的记忆。</CardDescription>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  {filters.map((filter) => {
+                    const active = filter.value === activeFilter;
+                    return (
+                      <button
+                        key={filter.value}
+                        type="button"
+                        onClick={() => setActiveFilter(filter.value)}
+                        className={cn(
+                          'rounded-full border px-3.5 py-1.5 text-sm transition',
+                          active
+                            ? 'border-zinc-100 bg-zinc-100 text-zinc-950'
+                            : 'border-zinc-800 bg-zinc-950 text-zinc-300 hover:border-zinc-700 hover:text-zinc-100'
+                        )}
+                      >
+                        {filter.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </CardHeader>
+            </Card>
+
+            <Card className="border-zinc-800 bg-zinc-900/55 shadow-none">
+              <CardHeader>
+                <CardTitle className="text-lg text-white">记忆列表</CardTitle>
+                <CardDescription className="text-zinc-500">
+                  当前显示 {memories.length} 条记忆，按重要度和更新时间排序
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="px-0 pb-0">
+                {isLoading ? (
+                  <div className="mx-6 mb-6 rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-8 text-center text-sm text-zinc-500">
+                    正在加载记忆...
+                  </div>
+                ) : memories.length === 0 ? (
+                  <div className="mx-6 mb-6 rounded-xl border border-dashed border-zinc-800 bg-zinc-950 px-6 py-10 text-center">
+                    <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full border border-zinc-800 bg-zinc-900 text-zinc-400">
+                      <Brain className="h-4 w-4" />
+                    </div>
+                    <div className="text-sm text-zinc-300">当前没有符合条件的记忆</div>
+                    <div className="mt-2 text-sm text-zinc-500">你可以手动新增一条，或者先在聊天里继续交流。</div>
+                  </div>
+                ) : (
+                  <div className="divide-y divide-zinc-800 border-t border-zinc-800">
+                    {memories.map((memory) => (
+                      <div key={memory.id} className="px-6 py-5 transition hover:bg-zinc-950/40">
+                        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                          <div className="min-w-0 flex-1">
+                            <div className="mb-2 flex flex-wrap items-center gap-2">
+                              <span className="rounded-full border border-zinc-700 px-2.5 py-1 text-xs text-zinc-200">
+                                {getMemoryTypeLabel(memory.memory_type)}
+                              </span>
+                              <span className="text-xs text-zinc-500">重要度 {memory.importance}/10</span>
+                            </div>
+                            <p className="text-sm leading-7 text-zinc-100">{memory.content}</p>
+                            <div className="mt-2 text-xs text-zinc-500">
+                              更新于 {formatDate(memory.updated_at)}
+                            </div>
+                          </div>
+
+                          <div className="flex shrink-0 gap-2">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleEditClick(memory)}
+                              className="text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
+                            >
+                              <Pencil className="mr-1.5 h-3.5 w-3.5" />
+                              编辑
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleDelete(memory)}
+                              className="text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
+                            >
+                              <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+                              删除
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+        </div>
+      </div>
+
+      <MemoryEditorModal
+        isOpen={showForm}
+        editingMemoryId={editingMemoryId}
+        formData={formData}
+        isSubmitting={isSubmitting}
+        onClose={resetForm}
+        onSubmit={handleSubmit}
+        onChange={setFormData}
+      />
+
+      <div className="pointer-events-none fixed right-4 top-4 z-50 space-y-2">
+        {toasts.map((toast) => {
+          const toneClass = toast.type === 'success'
+            ? 'border-emerald-900 bg-emerald-950/80 text-emerald-100'
+            : toast.type === 'error'
+              ? 'border-red-900 bg-red-950/80 text-red-100'
+              : 'border-zinc-700 bg-zinc-900 text-zinc-100';
+
+          return (
+            <div
+              key={toast.id}
+              className={cn(
+                'pointer-events-auto flex min-w-[220px] items-center gap-3 rounded-xl border px-4 py-3 text-sm shadow-lg',
+                toneClass
+              )}
+            >
+              <span className="h-2 w-2 rounded-full bg-current opacity-80" />
+              <span>{toast.message}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/internal/app/aiguide/assistant/memory_api.go
+++ b/internal/app/aiguide/assistant/memory_api.go
@@ -1,0 +1,367 @@
+package assistant
+
+import (
+	"aiguide/internal/app/aiguide/table"
+	"aiguide/internal/pkg/constant"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+const (
+	defaultMemoryLimit      = 50
+	maxMemoryLimit          = 200
+	defaultMemoryImportance = 5
+	maxMemoryContentLength  = 2000
+)
+
+type MemoryInfo struct {
+	ID         int                 `json:"id"`
+	MemoryType constant.MemoryType `json:"memory_type"`
+	Content    string              `json:"content"`
+	Importance int                 `json:"importance"`
+	CreatedAt  time.Time           `json:"created_at"`
+	UpdatedAt  time.Time           `json:"updated_at"`
+}
+
+type ListMemoriesResponse struct {
+	Memories []MemoryInfo `json:"memories"`
+	Total    int64        `json:"total"`
+	Limit    int          `json:"limit"`
+	Offset   int          `json:"offset"`
+}
+
+type CreateMemoryRequest struct {
+	MemoryType constant.MemoryType `json:"memory_type"`
+	Content    string              `json:"content" binding:"required"`
+	Importance int                 `json:"importance"`
+}
+
+type UpdateMemoryRequest struct {
+	MemoryType *constant.MemoryType `json:"memory_type"`
+	Content    *string              `json:"content"`
+	Importance *int                 `json:"importance"`
+}
+
+type MemorySummaryResponse struct {
+	Total         int64            `json:"total"`
+	Counts        map[string]int64 `json:"counts"`
+	LastUpdatedAt *time.Time       `json:"last_updated_at,omitempty"`
+}
+
+// ListMemories 返回当前用户的记忆列表。
+func (a *Assistant) ListMemories(ctx *gin.Context) {
+	userID, ok := getContextUserID(ctx)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	memoryType, hasType, valid := parseMemoryTypeQuery(ctx.Query("type"))
+	if hasType && !valid {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid memory type"})
+		return
+	}
+
+	limit := parseQueryInt(ctx.Query("limit"), defaultMemoryLimit)
+	if limit <= 0 {
+		limit = defaultMemoryLimit
+	}
+	if limit > maxMemoryLimit {
+		limit = maxMemoryLimit
+	}
+
+	offset := parseQueryInt(ctx.Query("offset"), 0)
+	if offset < 0 {
+		offset = 0
+	}
+
+	keyword := strings.TrimSpace(ctx.Query("keyword"))
+
+	query := a.db.Model(&table.UserMemory{}).Where("user_id = ?", userID)
+	if hasType {
+		query = query.Where("memory_type = ?", memoryType)
+	}
+	if keyword != "" {
+		query = query.Where("content LIKE ?", "%"+keyword+"%")
+	}
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		slog.Error("query.Count() error", "err", err, "user_id", userID)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load memories"})
+		return
+	}
+
+	var memories []table.UserMemory
+	if err := query.Order("importance DESC, updated_at DESC, id DESC").Limit(limit).Offset(offset).Find(&memories).Error; err != nil {
+		slog.Error("query.Find() error", "err", err, "user_id", userID)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load memories"})
+		return
+	}
+
+	response := make([]MemoryInfo, 0, len(memories))
+	for _, memory := range memories {
+		response = append(response, newMemoryInfo(memory))
+	}
+
+	ctx.JSON(http.StatusOK, ListMemoriesResponse{
+		Memories: response,
+		Total:    total,
+		Limit:    limit,
+		Offset:   offset,
+	})
+}
+
+// CreateMemory 为当前用户创建一条记忆。
+func (a *Assistant) CreateMemory(ctx *gin.Context) {
+	userID, ok := getContextUserID(ctx)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	var req CreateMemoryRequest
+	if err := ctx.BindJSON(&req); err != nil {
+		slog.Error("ctx.BindJSON() error", "err", err)
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	content := strings.TrimSpace(req.Content)
+	if content == "" || len([]rune(content)) > maxMemoryContentLength {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid memory content"})
+		return
+	}
+
+	memoryType := req.MemoryType
+	if memoryType == "" {
+		memoryType = constant.MemoryTypeFact
+	}
+	if !memoryType.Valid() {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid memory type"})
+		return
+	}
+
+	importance := normalizeMemoryImportance(req.Importance)
+
+	memory := table.UserMemory{
+		UserID:     userID,
+		MemoryType: memoryType,
+		Content:    content,
+		Importance: importance,
+	}
+	if err := a.db.Create(&memory).Error; err != nil {
+		slog.Error("db.Create() error", "err", err, "user_id", userID)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create memory"})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, newMemoryInfo(memory))
+}
+
+// UpdateMemory 更新当前用户的一条记忆。
+func (a *Assistant) UpdateMemory(ctx *gin.Context) {
+	userID, ok := getContextUserID(ctx)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	memoryID, err := strconv.Atoi(ctx.Param("memoryId"))
+	if err != nil || memoryID <= 0 {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid memory id"})
+		return
+	}
+
+	var req UpdateMemoryRequest
+	if err := ctx.BindJSON(&req); err != nil {
+		slog.Error("ctx.BindJSON() error", "err", err)
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	if req.MemoryType == nil && req.Content == nil && req.Importance == nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "no fields to update"})
+		return
+	}
+
+	var memory table.UserMemory
+	if err := a.db.Where("id = ? AND user_id = ?", memoryID, userID).First(&memory).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": "memory not found"})
+			return
+		}
+		slog.Error("db.First() error", "err", err, "user_id", userID, "memory_id", memoryID)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update memory"})
+		return
+	}
+
+	if req.MemoryType != nil {
+		if !req.MemoryType.Valid() {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid memory type"})
+			return
+		}
+		memory.MemoryType = *req.MemoryType
+	}
+
+	if req.Content != nil {
+		content := strings.TrimSpace(*req.Content)
+		if content == "" || len([]rune(content)) > maxMemoryContentLength {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid memory content"})
+			return
+		}
+		memory.Content = content
+	}
+
+	if req.Importance != nil {
+		if *req.Importance < 1 || *req.Importance > 10 {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid importance"})
+			return
+		}
+		memory.Importance = *req.Importance
+	}
+
+	if err := a.db.Save(&memory).Error; err != nil {
+		slog.Error("db.Save() error", "err", err, "user_id", userID, "memory_id", memoryID)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update memory"})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, newMemoryInfo(memory))
+}
+
+// DeleteMemory 删除当前用户的一条记忆。
+func (a *Assistant) DeleteMemory(ctx *gin.Context) {
+	userID, ok := getContextUserID(ctx)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	memoryID, err := strconv.Atoi(ctx.Param("memoryId"))
+	if err != nil || memoryID <= 0 {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid memory id"})
+		return
+	}
+
+	result := a.db.Where("id = ? AND user_id = ?", memoryID, userID).Delete(&table.UserMemory{})
+	if result.Error != nil {
+		slog.Error("db.Delete() error", "err", result.Error, "user_id", userID, "memory_id", memoryID)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete memory"})
+		return
+	}
+	if result.RowsAffected == 0 {
+		ctx.JSON(http.StatusNotFound, gin.H{"error": "memory not found"})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"id": memoryID})
+}
+
+// GetMemorySummary 返回当前用户记忆概览。
+func (a *Assistant) GetMemorySummary(ctx *gin.Context) {
+	userID, ok := getContextUserID(ctx)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	type countRow struct {
+		MemoryType constant.MemoryType `json:"memory_type"`
+		Count      int64               `json:"count"`
+	}
+
+	counts := map[string]int64{
+		constant.MemoryTypeFact.String():       0,
+		constant.MemoryTypePreference.String(): 0,
+		constant.MemoryTypeContext.String():    0,
+	}
+
+	var total int64
+	if err := a.db.Model(&table.UserMemory{}).Where("user_id = ?", userID).Count(&total).Error; err != nil {
+		slog.Error("db.Count() error", "err", err, "user_id", userID)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load memory summary"})
+		return
+	}
+
+	var rows []countRow
+	if err := a.db.Model(&table.UserMemory{}).
+		Select("memory_type, COUNT(*) AS count").
+		Where("user_id = ?", userID).
+		Group("memory_type").
+		Scan(&rows).Error; err != nil {
+		slog.Error("db.Scan() error", "err", err, "user_id", userID)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load memory summary"})
+		return
+	}
+
+	for _, row := range rows {
+		counts[row.MemoryType.String()] = row.Count
+	}
+
+	var latestMemory table.UserMemory
+	var lastUpdatedAt *time.Time
+	if err := a.db.Where("user_id = ?", userID).Order("updated_at DESC, id DESC").First(&latestMemory).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			slog.Error("db.First() error", "err", err, "user_id", userID)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load memory summary"})
+			return
+		}
+	} else {
+		lastUpdatedAt = &latestMemory.UpdatedAt
+	}
+
+	ctx.JSON(http.StatusOK, MemorySummaryResponse{
+		Total:         total,
+		Counts:        counts,
+		LastUpdatedAt: lastUpdatedAt,
+	})
+}
+
+func newMemoryInfo(memory table.UserMemory) MemoryInfo {
+	return MemoryInfo{
+		ID:         memory.ID,
+		MemoryType: memory.MemoryType,
+		Content:    memory.Content,
+		Importance: memory.Importance,
+		CreatedAt:  memory.CreatedAt,
+		UpdatedAt:  memory.UpdatedAt,
+	}
+}
+
+func parseMemoryTypeQuery(raw string) (constant.MemoryType, bool, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", false, true
+	}
+
+	memoryType := constant.MemoryType(trimmed)
+	return memoryType, true, memoryType.Valid()
+}
+
+func parseQueryInt(raw string, fallback int) int {
+	if strings.TrimSpace(raw) == "" {
+		return fallback
+	}
+
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return fallback
+	}
+
+	return value
+}
+
+func normalizeMemoryImportance(importance int) int {
+	if importance < 1 || importance > 10 {
+		return defaultMemoryImportance
+	}
+	return importance
+}

--- a/internal/app/aiguide/assistant/memory_api_test.go
+++ b/internal/app/aiguide/assistant/memory_api_test.go
@@ -1,0 +1,240 @@
+package assistant
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"aiguide/internal/app/aiguide/table"
+	"aiguide/internal/pkg/constant"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestListMemoriesAndSummary(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	assistant := setupProjectTestAssistant(t)
+
+	seedMemories := []table.UserMemory{
+		{UserID: 1, MemoryType: constant.MemoryTypeFact, Content: "用户是 Go 工程师", Importance: 9},
+		{UserID: 1, MemoryType: constant.MemoryTypePreference, Content: "偏好简洁回答", Importance: 7},
+		{UserID: 1, MemoryType: constant.MemoryTypeContext, Content: "正在开发 AIGuides", Importance: 8},
+		{UserID: 2, MemoryType: constant.MemoryTypeFact, Content: "其他用户数据", Importance: 10},
+	}
+	for _, memory := range seedMemories {
+		if err := assistant.db.Create(&memory).Error; err != nil {
+			t.Fatalf("failed to create memory: %v", err)
+		}
+	}
+
+	router := newProjectTestRouter(assistant, func(router *gin.Engine) {
+		router.GET("/api/assistant/memories", assistant.ListMemories)
+		router.GET("/api/assistant/memories/summary", assistant.GetMemorySummary)
+	})
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/assistant/memories?type=fact&keyword=Go", nil)
+	listResp := httptest.NewRecorder()
+	router.ServeHTTP(listResp, listReq)
+
+	if listResp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, listResp.Code, listResp.Body.String())
+	}
+
+	var listResponse ListMemoriesResponse
+	if err := json.Unmarshal(listResp.Body.Bytes(), &listResponse); err != nil {
+		t.Fatalf("failed to unmarshal list response: %v", err)
+	}
+	if listResponse.Total != 1 {
+		t.Fatalf("expected total 1, got %d", listResponse.Total)
+	}
+	if len(listResponse.Memories) != 1 {
+		t.Fatalf("expected 1 memory, got %d", len(listResponse.Memories))
+	}
+	if listResponse.Memories[0].Content != "用户是 Go 工程师" {
+		t.Fatalf("unexpected memory content: %+v", listResponse.Memories[0])
+	}
+
+	summaryReq := httptest.NewRequest(http.MethodGet, "/api/assistant/memories/summary", nil)
+	summaryResp := httptest.NewRecorder()
+	router.ServeHTTP(summaryResp, summaryReq)
+
+	if summaryResp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, summaryResp.Code, summaryResp.Body.String())
+	}
+
+	var summary MemorySummaryResponse
+	if err := json.Unmarshal(summaryResp.Body.Bytes(), &summary); err != nil {
+		t.Fatalf("failed to unmarshal summary response: %v", err)
+	}
+	if summary.Total != 3 {
+		t.Fatalf("expected total 3, got %d", summary.Total)
+	}
+	if summary.Counts[constant.MemoryTypeFact.String()] != 1 {
+		t.Fatalf("expected fact count 1, got %d", summary.Counts[constant.MemoryTypeFact.String()])
+	}
+	if summary.Counts[constant.MemoryTypePreference.String()] != 1 {
+		t.Fatalf("expected preference count 1, got %d", summary.Counts[constant.MemoryTypePreference.String()])
+	}
+	if summary.LastUpdatedAt == nil {
+		t.Fatal("expected last_updated_at to be set")
+	}
+}
+
+func TestCreateUpdateAndDeleteMemory(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	assistant := setupProjectTestAssistant(t)
+	router := newProjectTestRouter(assistant, func(router *gin.Engine) {
+		router.POST("/api/assistant/memories", assistant.CreateMemory)
+		router.PATCH("/api/assistant/memories/:memoryId", assistant.UpdateMemory)
+		router.DELETE("/api/assistant/memories/:memoryId", assistant.DeleteMemory)
+	})
+
+	createBody, err := json.Marshal(CreateMemoryRequest{
+		MemoryType: constant.MemoryTypeFact,
+		Content:    "擅长 Go 和微服务",
+		Importance: 9,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal create request: %v", err)
+	}
+
+	createReq := httptest.NewRequest(http.MethodPost, "/api/assistant/memories", bytes.NewBuffer(createBody))
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp := httptest.NewRecorder()
+	router.ServeHTTP(createResp, createReq)
+
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, createResp.Code, createResp.Body.String())
+	}
+
+	var created MemoryInfo
+	if err := json.Unmarshal(createResp.Body.Bytes(), &created); err != nil {
+		t.Fatalf("failed to unmarshal create response: %v", err)
+	}
+	if created.ID == 0 {
+		t.Fatal("expected created memory id to be set")
+	}
+	if created.Importance != 9 {
+		t.Fatalf("expected importance 9, got %d", created.Importance)
+	}
+
+	updatedContent := "擅长 Go、微服务和 AI 工具开发"
+	updatedType := constant.MemoryTypeContext
+	updatedImportance := 10
+	updateBody, err := json.Marshal(UpdateMemoryRequest{
+		MemoryType: &updatedType,
+		Content:    &updatedContent,
+		Importance: &updatedImportance,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal update request: %v", err)
+	}
+
+	updateReq := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/assistant/memories/%d", created.ID), bytes.NewBuffer(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateResp := httptest.NewRecorder()
+	router.ServeHTTP(updateResp, updateReq)
+
+	if updateResp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, updateResp.Code, updateResp.Body.String())
+	}
+
+	var updated MemoryInfo
+	if err := json.Unmarshal(updateResp.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("failed to unmarshal update response: %v", err)
+	}
+	if updated.MemoryType != constant.MemoryTypeContext {
+		t.Fatalf("expected memory type %q, got %q", constant.MemoryTypeContext, updated.MemoryType)
+	}
+	if updated.Content != updatedContent {
+		t.Fatalf("expected content %q, got %q", updatedContent, updated.Content)
+	}
+	if updated.Importance != updatedImportance {
+		t.Fatalf("expected importance %d, got %d", updatedImportance, updated.Importance)
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/assistant/memories/%d", created.ID), nil)
+	deleteResp := httptest.NewRecorder()
+	router.ServeHTTP(deleteResp, deleteReq)
+
+	if deleteResp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusOK, deleteResp.Code, deleteResp.Body.String())
+	}
+
+	var count int64
+	if err := assistant.db.Model(&table.UserMemory{}).Where("id = ?", created.ID).Count(&count).Error; err != nil {
+		t.Fatalf("failed to count memories: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected memory to be deleted, count=%d", count)
+	}
+}
+
+func TestMemoryEndpointsValidateOwnershipAndInput(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	assistant := setupProjectTestAssistant(t)
+	otherUserMemory := table.UserMemory{
+		UserID:     2,
+		MemoryType: constant.MemoryTypeFact,
+		Content:    "其他用户的记忆",
+		Importance: 6,
+	}
+	if err := assistant.db.Create(&otherUserMemory).Error; err != nil {
+		t.Fatalf("failed to create memory: %v", err)
+	}
+
+	router := newProjectTestRouter(assistant, func(router *gin.Engine) {
+		router.GET("/api/assistant/memories", assistant.ListMemories)
+		router.POST("/api/assistant/memories", assistant.CreateMemory)
+		router.PATCH("/api/assistant/memories/:memoryId", assistant.UpdateMemory)
+		router.DELETE("/api/assistant/memories/:memoryId", assistant.DeleteMemory)
+	})
+
+	invalidListReq := httptest.NewRequest(http.MethodGet, "/api/assistant/memories?type=invalid", nil)
+	invalidListResp := httptest.NewRecorder()
+	router.ServeHTTP(invalidListResp, invalidListReq)
+	if invalidListResp.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, invalidListResp.Code)
+	}
+
+	invalidCreateBody := []byte(`{"memory_type":"fact","content":"   ","importance":11}`)
+	invalidCreateReq := httptest.NewRequest(http.MethodPost, "/api/assistant/memories", bytes.NewBuffer(invalidCreateBody))
+	invalidCreateReq.Header.Set("Content-Type", "application/json")
+	invalidCreateResp := httptest.NewRecorder()
+	router.ServeHTTP(invalidCreateResp, invalidCreateReq)
+	if invalidCreateResp.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, invalidCreateResp.Code)
+	}
+
+	updateContent := "不能更新别人的记忆"
+	updateBody, err := json.Marshal(UpdateMemoryRequest{Content: &updateContent})
+	if err != nil {
+		t.Fatalf("failed to marshal update request: %v", err)
+	}
+	updateReq := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/assistant/memories/%d", otherUserMemory.ID), bytes.NewBuffer(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateResp := httptest.NewRecorder()
+	router.ServeHTTP(updateResp, updateReq)
+	if updateResp.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, updateResp.Code)
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/assistant/memories/%d", otherUserMemory.ID), nil)
+	deleteResp := httptest.NewRecorder()
+	router.ServeHTTP(deleteResp, deleteReq)
+	if deleteResp.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, deleteResp.Code)
+	}
+
+	var memory table.UserMemory
+	if err := assistant.db.First(&memory, otherUserMemory.ID).Error; err != nil {
+		t.Fatalf("expected memory to remain, got error: %v", err)
+	}
+	if memory.DeletedAt != nil && memory.DeletedAt.Before(time.Now()) {
+		t.Fatal("expected other user's memory to remain undeleted")
+	}
+}

--- a/internal/app/aiguide/router.go
+++ b/internal/app/aiguide/router.go
@@ -48,6 +48,15 @@ func (a *AIGuide) initRouter(engine *gin.Engine) error {
 		shareGroup.DELETE("/:shareId", a.assistant.DeleteShare)
 	}
 
+	memoryGroup := api.Group("/assistant/memories")
+	{
+		memoryGroup.GET("", a.assistant.ListMemories)
+		memoryGroup.POST("", a.assistant.CreateMemory)
+		memoryGroup.GET("/summary", a.assistant.GetMemorySummary)
+		memoryGroup.PATCH("/:memoryId", a.assistant.UpdateMemory)
+		memoryGroup.DELETE("/:memoryId", a.assistant.DeleteMemory)
+	}
+
 	projectGroup := api.Group("/assistant/projects")
 	{
 		projectGroup.GET("", a.assistant.ListProjects)


### PR DESCRIPTION
## Summary

- Add memory management REST API (`/api/assistant/memories`) with CRUD endpoints and summary
- Add frontend memory center page (`/memory`) with filtering, search, and editing
- Add "记忆中心" entry in sidebar user menu with Brain icon