### PR TITLE
feat: show tool call arguments in chat UI

### DIFF
--- a/frontend/app/chat/[sessionId]/components/MessageContent.tsx
+++ b/frontend/app/chat/[sessionId]/components/MessageContent.tsx
@@ -29,6 +29,7 @@ export const AIMessageContent = memo(({
   toolCalls,
 }: AIMessageContentProps) => {
   const [showRaw, setShowRaw] = useState(false);
+  const [expandedToolCallIndexes, setExpandedToolCallIndexes] = useState<number[]>([]);
   const [isThoughtExpanded, setIsThoughtExpanded] = useState(() => {
     if (!thought || !thoughtStorageKey || typeof window === 'undefined') return false;
 
@@ -93,6 +94,20 @@ export const AIMessageContent = memo(({
     }
   };
 
+  const toggleToolArgs = (index: number) => {
+    setExpandedToolCallIndexes((prev) => (
+      prev.includes(index) ? prev.filter((item) => item !== index) : [...prev, index]
+    ));
+  };
+
+  const formatToolArgs = (args?: Record<string, unknown>) => {
+    if (!args || Object.keys(args).length === 0) {
+      return '';
+    }
+
+    return JSON.stringify(args, null, 2);
+  };
+
   return (
     <div className="group">
       {/* Thought Process section */}
@@ -138,18 +153,40 @@ export const AIMessageContent = memo(({
           {toolCalls.map((tc, i) => (
             <div
               key={i}
-              className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/40 border border-muted-foreground/10 px-3 py-1.5 rounded-md w-fit"
+              className="text-xs text-muted-foreground bg-muted/40 border border-muted-foreground/10 rounded-md overflow-hidden max-w-full"
             >
-              {isStreaming && i === toolCalls.length - 1 ? (
-                <div className="flex space-x-0.5">
-                  <div className="w-1 h-1 bg-primary/60 rounded-full animate-bounce [animation-delay:-0.3s]" />
-                  <div className="w-1 h-1 bg-primary/60 rounded-full animate-bounce [animation-delay:-0.15s]" />
-                  <div className="w-1 h-1 bg-primary/60 rounded-full animate-bounce" />
-                </div>
-              ) : (
-                <div className="w-1 h-1 bg-muted-foreground/40 rounded-full" />
+              <div className="flex items-center gap-2 px-3 py-1.5">
+                {isStreaming && i === toolCalls.length - 1 ? (
+                  <div className="flex space-x-0.5 shrink-0">
+                    <div className="w-1 h-1 bg-primary/60 rounded-full animate-bounce [animation-delay:-0.3s]" />
+                    <div className="w-1 h-1 bg-primary/60 rounded-full animate-bounce [animation-delay:-0.15s]" />
+                    <div className="w-1 h-1 bg-primary/60 rounded-full animate-bounce" />
+                  </div>
+                ) : (
+                  <div className="w-1 h-1 bg-muted-foreground/40 rounded-full shrink-0" />
+                )}
+                <span className="min-w-0 flex-1 break-all">{tc.label}</span>
+                {tc.args && Object.keys(tc.args).length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => toggleToolArgs(i)}
+                    className="inline-flex items-center gap-1 rounded border border-muted-foreground/15 px-2 py-0.5 text-[11px] hover:bg-muted/60 transition-colors shrink-0"
+                    aria-expanded={expandedToolCallIndexes.includes(i)}
+                  >
+                    {expandedToolCallIndexes.includes(i) ? (
+                      <ChevronDown className="h-3 w-3" />
+                    ) : (
+                      <ChevronRight className="h-3 w-3" />
+                    )}
+                    <span>参数</span>
+                  </button>
+                )}
+              </div>
+              {tc.args && Object.keys(tc.args).length > 0 && expandedToolCallIndexes.includes(i) && (
+                <pre className="border-t border-muted-foreground/10 bg-background/70 px-3 py-2 overflow-x-auto whitespace-pre-wrap break-all text-[11px] leading-relaxed">
+                  {formatToolArgs(tc.args)}
+                </pre>
               )}
-              <span>{tc.label}</span>
             </div>
           ))}
         </div>

--- a/frontend/app/chat/[sessionId]/page.tsx
+++ b/frontend/app/chat/[sessionId]/page.tsx
@@ -10,7 +10,7 @@ import { Check, Copy, Menu, Pencil, X, Share2 } from 'lucide-react';
 import { cn } from '@/app/lib/utils';
 
 // 导入类型和常量
-import type { Message, SelectedImage } from './types';
+import type { HistoryMessageResponse, Message, SelectedImage, SessionHistoryResponse, ToolCallResponse } from './types';
 import { agentInfoMap, MESSAGES_PER_PAGE, LOAD_MORE_THRESHOLD, SCROLL_RESET_DELAY } from './constants';
 
 // 导入组件
@@ -52,6 +52,23 @@ export default function ChatPage() {
   const [isCreateProjectModalOpen, setIsCreateProjectModalOpen] = useState(false);
   const [renamingProject, setRenamingProject] = useState<Project | null>(null);
   const [quotedText, setQuotedText] = useState('');
+
+  const mapToolCall = (toolCall: ToolCallResponse) => ({
+    toolName: toolCall.tool_name,
+    label: toolCall.label,
+    args: toolCall.args || undefined,
+  });
+
+  const mapHistoryMessage = (msg: HistoryMessageResponse): Message => ({
+    id: msg.id,
+    role: msg.role,
+    content: msg.content,
+    thought: msg.thought,
+    timestamp: new Date(msg.timestamp),
+    images: msg.images || [],
+    fileNames: msg.file_names || [],
+    toolCalls: (msg.tool_calls || []).map(mapToolCall),
+  });
 
   // 使用文件上传 hook
   const {
@@ -154,16 +171,8 @@ export default function ChatPage() {
     try {
       const response = await authenticatedFetch(`/api/${agentId}/sessions/${targetSessionId}/history?user_id=${user?.user_id}&limit=${MESSAGES_PER_PAGE}&offset=0`);
       if (response.ok) {
-        const data = await response.json();
-        const historyMessages = data.messages.map((msg: any) => ({
-          id: msg.id,
-          role: msg.role,
-          content: msg.content,
-          thought: msg.thought,
-          timestamp: new Date(msg.timestamp),
-          images: msg.images || [],
-          fileNames: msg.file_names || [],
-        }));
+        const data: SessionHistoryResponse = await response.json();
+        const historyMessages = data.messages.map(mapHistoryMessage);
         setMessages(historyMessages);
         setHasMoreMessages(data.has_more || false);
         setTotalMessageCount(data.total || 0);
@@ -200,16 +209,8 @@ export default function ChatPage() {
       const currentOffset = messages.length;
       const response = await authenticatedFetch(`/api/${agentId}/sessions/${sessionId}/history?user_id=${user?.user_id}&limit=${MESSAGES_PER_PAGE}&offset=${currentOffset}`);
       if (response.ok) {
-        const data = await response.json();
-        const olderMessages = data.messages.map((msg: any) => ({
-          id: msg.id,
-          role: msg.role,
-          content: msg.content,
-          thought: msg.thought,
-          timestamp: new Date(msg.timestamp),
-          images: msg.images || [],
-          fileNames: msg.file_names || [],
-        }));
+        const data: SessionHistoryResponse = await response.json();
+        const olderMessages = data.messages.map(mapHistoryMessage);
 
         setMessages(prev => [...olderMessages, ...prev]);
         setHasMoreMessages(data.has_more || false);
@@ -825,7 +826,11 @@ export default function ChatPage() {
                 }
 
                 if (currentEventType === 'tool_call') {
-                  const toolCall = { toolName: data.tool_name as string, label: data.tool_label as string };
+                  const toolCall = {
+                    toolName: data.tool_name as string,
+                    label: data.tool_label as string,
+                    args: (data.tool_args as Record<string, unknown> | undefined) || undefined,
+                  };
                   setMessages((prev) => {
                     const newMessages = [...prev];
                     const lastIndex = newMessages.length - 1;

--- a/frontend/app/chat/[sessionId]/types.ts
+++ b/frontend/app/chat/[sessionId]/types.ts
@@ -1,6 +1,13 @@
 export interface ToolCallItem {
   toolName: string;
   label: string;
+  args?: Record<string, unknown>;
+}
+
+export interface ToolCallResponse {
+  tool_name: string;
+  label: string;
+  args?: Record<string, unknown>;
 }
 
 export interface Message {
@@ -39,4 +46,21 @@ export interface ChatRequest {
   message: string;
   images: string[];
   file_names: string[];
+}
+
+export interface HistoryMessageResponse {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  thought?: string;
+  timestamp: string;
+  images?: string[];
+  file_names?: string[];
+  tool_calls?: ToolCallResponse[];
+}
+
+export interface SessionHistoryResponse {
+  messages: HistoryMessageResponse[];
+  total?: number;
+  has_more?: boolean;
 }

--- a/frontend/app/components/ui/input.tsx
+++ b/frontend/app/components/ui/input.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/app/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/frontend/app/components/ui/textarea.tsx
+++ b/frontend/app/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/app/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/internal/app/aiguide/assistant/session.go
+++ b/internal/app/aiguide/assistant/session.go
@@ -54,13 +54,20 @@ type SessionHistoryResponse struct {
 
 // MessageEvent 定义消息事件结构
 type MessageEvent struct {
-	ID        string    `json:"id"`
-	Timestamp time.Time `json:"timestamp"`
-	Role      string    `json:"role"` // "user" or "assistant"
-	Content   string    `json:"content"`
-	Thought   string    `json:"thought,omitempty"`
-	Images    []string  `json:"images,omitempty"`     // Base64编码的图片或PDF数据列表
-	FileNames []string  `json:"file_names,omitempty"` // 文件名列表，与 Images 对应
+	ID        string     `json:"id"`
+	Timestamp time.Time  `json:"timestamp"`
+	Role      string     `json:"role"` // "user" or "assistant"
+	Content   string     `json:"content"`
+	Thought   string     `json:"thought,omitempty"`
+	Images    []string   `json:"images,omitempty"`     // Base64编码的图片或PDF数据列表
+	FileNames []string   `json:"file_names,omitempty"` // 文件名列表，与 Images 对应
+	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
+}
+
+type ToolCall struct {
+	ToolName string         `json:"tool_name"`
+	Label    string         `json:"label"`
+	Args     map[string]any `json:"args,omitempty"`
 }
 
 // CreateSessionRequest 定义创建会话的请求结构
@@ -355,6 +362,7 @@ func buildMessageEvents(events session.Events) []MessageEvent {
 		thought := ""
 		var images []string
 		var fileNames []string
+		var toolCalls []ToolCall
 		hasFunctionResponse := false
 
 		for _, part := range event.Content.Parts {
@@ -403,13 +411,21 @@ func buildMessageEvents(events session.Events) []MessageEvent {
 					}
 				}
 			}
+
+			if part.FunctionCall != nil {
+				toolCalls = append(toolCalls, ToolCall{
+					ToolName: part.FunctionCall.Name,
+					Label:    toolCallLabel(part.FunctionCall.Name, part.FunctionCall.Args),
+					Args:     part.FunctionCall.Args,
+				})
+			}
 		}
 
 		if hasFunctionResponse {
 			role = "assistant"
 		}
 
-		if content != "" || thought != "" || len(images) > 0 {
+		if content != "" || thought != "" || len(images) > 0 || len(toolCalls) > 0 {
 			message := MessageEvent{
 				ID:        event.ID,
 				Timestamp: event.Timestamp,
@@ -418,6 +434,7 @@ func buildMessageEvents(events session.Events) []MessageEvent {
 				Thought:   thought,
 				Images:    images,
 				FileNames: fileNames,
+				ToolCalls: toolCalls,
 			}
 			if isDuplicateRetryUserMessage(allMessages, message) {
 				continue

--- a/internal/app/aiguide/assistant/sse.go
+++ b/internal/app/aiguide/assistant/sse.go
@@ -369,6 +369,7 @@ func (a *Assistant) streamAgentEvents(
 						"author":     event.Author,
 						"tool_name":  part.FunctionCall.Name,
 						"tool_label": label,
+						"tool_args":  part.FunctionCall.Args,
 					}
 					ctx.SSEvent("tool_call", data)
 					ctx.Writer.Flush()


### PR DESCRIPTION
## Summary
- expose tool call arguments from the assistant SSE stream and session history API so the frontend can render them consistently
- add expandable tool argument display in the chat UI for agent tool invocations
- fix shared input and textarea typing so frontend lint no longer fails on empty interface errors