### PR TITLE
feat: add SMTP email sending support

### DIFF
--- a/frontend/app/settings/email-servers/page.tsx
+++ b/frontend/app/settings/email-servers/page.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/app/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/app/components/ui/card';
 import { Alert, AlertDescription } from '@/app/components/ui/alert';
 import {
+  AlertTriangle,
   Plus,
   Trash2,
   Edit2,
@@ -22,6 +23,7 @@ import {
 interface EmailServerConfig {
   id: number;
   server: string;
+  smtp_server?: string;
   username: string;
   password?: string;
   mailbox: string;
@@ -33,6 +35,7 @@ interface EmailServerConfig {
 
 interface FormData {
   server: string;
+  smtp_server: string;
   username: string;
   password: string;
   mailbox: string;
@@ -54,9 +57,12 @@ export default function EmailServersPage() {
   const [configs, setConfigs] = useState<EmailServerConfig[]>([]);
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<EmailServerConfig | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
   const [showPassword, setShowPassword] = useState(false);
   const [formData, setFormData] = useState<FormData>({
     server: '',
+    smtp_server: '',
     username: '',
     password: '',
     mailbox: 'INBOX',
@@ -86,6 +92,21 @@ export default function EmailServersPage() {
       loadConfigs();
     }
   }, [user]);
+
+  useEffect(() => {
+    if (!deleteTarget) {
+      return;
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && deletingId === null) {
+        setDeleteTarget(null);
+      }
+    };
+
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, [deleteTarget, deletingId]);
 
   const loadConfigs = async () => {
     try {
@@ -164,6 +185,7 @@ export default function EmailServersPage() {
 
       setFormData({
         server: detail.server,
+        smtp_server: detail.smtp_server || '',
         username: detail.username,
         password: detail.password || '',
         mailbox: detail.mailbox || 'INBOX',
@@ -181,13 +203,18 @@ export default function EmailServersPage() {
     }
   };
 
-  const handleDelete = async (id: number) => {
-    if (!confirm('确定要删除这个邮件服务器配置吗？')) {
+  const handleDelete = (config: EmailServerConfig) => {
+    setDeleteTarget(config);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) {
       return;
     }
 
+    setDeletingId(deleteTarget.id);
     try {
-      const response = await fetch(`/api/email_server_configs/${id}`, {
+      const response = await fetch(`/api/email_server_configs/${deleteTarget.id}`, {
         method: 'DELETE',
         credentials: 'include',
       });
@@ -195,6 +222,7 @@ export default function EmailServersPage() {
       if (response.ok) {
         const msg = '删除成功';
         notify(msg, 'success');
+        setDeleteTarget(null);
         await loadConfigs();
       } else {
         const data = await response.json();
@@ -204,12 +232,15 @@ export default function EmailServersPage() {
     } catch (err) {
       const msg = '删除失败: ' + (err as Error).message;
       notify(msg, 'error');
+    } finally {
+      setDeletingId(null);
     }
   };
 
   const resetForm = () => {
     setFormData({
       server: '',
+      smtp_server: '',
       username: '',
       password: '',
       mailbox: 'INBOX',
@@ -239,6 +270,57 @@ export default function EmailServersPage() {
 
   return (
     <div className="min-h-screen bg-background">
+      {deleteTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4 backdrop-blur-sm">
+          <div className="w-full max-w-md overflow-hidden rounded-2xl border border-red-100 bg-white shadow-2xl">
+            <div className="bg-[linear-gradient(135deg,#fff1f2_0%,#ffffff_65%)] px-6 py-5">
+              <div className="flex items-start gap-4">
+                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-red-100 text-red-600 shadow-sm">
+                  <AlertTriangle className="h-5 w-5" />
+                </div>
+                <div className="space-y-1">
+                  <h2 className="text-lg font-semibold text-slate-900">
+                    删除邮件服务器配置？
+                  </h2>
+                  <p className="text-sm leading-6 text-slate-600">
+                    这会移除 <span className="font-medium text-slate-900">{deleteTarget.name}</span>{' '}
+                    的邮箱连接设置，AI 将无法继续使用这个账号查询或发送邮件。
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-4 px-6 py-5">
+              <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+                <div className="font-medium text-slate-900">{deleteTarget.username}</div>
+                <div className="mt-1">IMAP: {deleteTarget.server}</div>
+                <div className="mt-1">SMTP: {deleteTarget.smtp_server || '未配置'}</div>
+              </div>
+
+              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setDeleteTarget(null)}
+                  disabled={deletingId !== null}
+                >
+                  取消
+                </Button>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={confirmDelete}
+                  disabled={deletingId !== null}
+                  className="min-w-28"
+                >
+                  {deletingId === deleteTarget.id ? '删除中...' : '确认删除'}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="container mx-auto px-4 py-8 max-w-4xl">
         <div className="mb-6 flex items-center justify-between">
           <div className="flex items-center gap-4">
@@ -297,7 +379,7 @@ export default function EmailServersPage() {
             <CardHeader>
               <CardTitle>{editingId ? '编辑' : '添加'}邮件服务器</CardTitle>
               <CardDescription>
-                输入 IMAP 服务器信息以连接您的邮箱
+                输入 IMAP/SMTP 服务器信息以查询和发送邮件
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -332,6 +414,23 @@ export default function EmailServersPage() {
                   />
                   <p className="text-xs text-muted-foreground mt-1">
                     IMAP 服务器地址和端口，通常是 993
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium mb-2">
+                    SMTP 服务器地址
+                  </label>
+                  <Input
+                    type="text"
+                    value={formData.smtp_server}
+                    onChange={(e) =>
+                      setFormData({ ...formData, smtp_server: e.target.value })
+                    }
+                    placeholder="例如: smtp.gmail.com:587"
+                  />
+                  <p className="text-xs text-muted-foreground mt-1">
+                    可选；配置后 AI 助手可使用该账号发送邮件，通常使用 587 或 465 端口
                   </p>
                 </div>
 
@@ -452,7 +551,7 @@ export default function EmailServersPage() {
                   还没有配置邮件服务器
                 </h3>
                 <p className="text-muted-foreground mb-4">
-                  添加邮件服务器配置后，AI 助手将能够帮您查询邮件
+                  添加邮件服务器配置后，AI 助手将能够帮您查询邮件；补充 SMTP 地址后也可发送邮件
                 </p>
                 {!showForm && (
                   <Button onClick={() => setShowForm(true)}>
@@ -493,7 +592,7 @@ export default function EmailServersPage() {
                       <Button
                         variant="ghost"
                         size="icon"
-                        onClick={() => handleDelete(config.id)}
+                        onClick={() => handleDelete(config)}
                       >
                         <Trash2 className="h-4 w-4 text-destructive" />
                       </Button>
@@ -505,6 +604,10 @@ export default function EmailServersPage() {
                     <div>
                       <span className="text-muted-foreground">服务器：</span>
                       <span className="ml-2">{config.server}</span>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">SMTP：</span>
+                      <span className="ml-2">{config.smtp_server || '未配置'}</span>
                     </div>
                     <div>
                       <span className="text-muted-foreground">邮箱文件夹：</span>

--- a/internal/app/aiguide/assistant/agent_test.go
+++ b/internal/app/aiguide/assistant/agent_test.go
@@ -106,6 +106,7 @@ func TestAssistantAgentInstructionOnlyMentionsRootTools(t *testing.T) {
 		"`current_time`",
 		"`image_gen`",
 		"`email_query`",
+		"`send_email`",
 		"`web_search`",
 		"`exa_search`",
 		"`web_fetch`",

--- a/internal/app/aiguide/assistant/executor_agent.go
+++ b/internal/app/aiguide/assistant/executor_agent.go
@@ -48,6 +48,11 @@ func NewExecutorAgent(config *ExecutorAgentConfig) (agent.Agent, error) {
 		return nil, fmt.Errorf("failed to create email query tool: %w", err)
 	}
 
+	sendEmailTool, err := tools.NewSendEmailTool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create send email tool: %w", err)
+	}
+
 	webSearchTool, err := tools.NewWebSearchTool(config.WebSearchConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create web search tool: %w", err)
@@ -86,7 +91,7 @@ func NewExecutorAgent(config *ExecutorAgentConfig) (agent.Agent, error) {
 
 	agentConfig := llmagent.Config{
 		Name:        "executor",
-		Description: "Specialized agent for executing tasks using tools like image generation, email queries, web search, and web fetching",
+		Description: "Specialized agent for executing tasks using tools like image generation, email queries, email sending, web search, and web fetching",
 		Model:       config.Model,
 		GenerateContentConfig: &genai.GenerateContentConfig{
 			ThinkingConfig: &genai.ThinkingConfig{
@@ -98,6 +103,7 @@ func NewExecutorAgent(config *ExecutorAgentConfig) (agent.Agent, error) {
 			currentTimeTool, // Get current date/time - use before web_search for time-sensitive queries
 			imageGenTool,
 			emailQueryTool,
+			sendEmailTool,
 			webSearchTool,
 			exaSearchTool,
 			webFetchTool,

--- a/internal/app/aiguide/assistant/executor_agent_prompt.md
+++ b/internal/app/aiguide/assistant/executor_agent_prompt.md
@@ -28,6 +28,7 @@
 - `current_time`: 获取当前日期时间（时间敏感问题先用）
 - `image_gen`: 生成图片
 - `email_query`: 查询邮件（IMAP）
+- `send_email`: 发送邮件（SMTP）
 - `web_search`: 获取最新/时效信息
 - `exa_search`: 语义搜索（深度理解/高质量资料）
 - `web_fetch`: 抓取网页内容

--- a/internal/app/aiguide/setting/email_server_config.go
+++ b/internal/app/aiguide/setting/email_server_config.go
@@ -13,25 +13,27 @@ import (
 
 // EmailServerConfigRequest 邮件服务器配置请求
 type EmailServerConfigRequest struct {
-	Server    string `json:"server" binding:"required"`
-	Username  string `json:"username" binding:"required"`
-	Password  string `json:"password" binding:"required"`
-	Mailbox   string `json:"mailbox"`
-	Name      string `json:"name" binding:"required"`
-	IsDefault bool   `json:"is_default"`
+	Server     string `json:"server" binding:"required"`
+	SMTPServer string `json:"smtp_server"`
+	Username   string `json:"username" binding:"required"`
+	Password   string `json:"password" binding:"required"`
+	Mailbox    string `json:"mailbox"`
+	Name       string `json:"name" binding:"required"`
+	IsDefault  bool   `json:"is_default"`
 }
 
 // EmailServerConfigResponse 邮件服务器配置响应
 type EmailServerConfigResponse struct {
-	ID        int       `json:"id"`
-	Server    string    `json:"server"`
-	Username  string    `json:"username"`
-	Password  string    `json:"password"`
-	Mailbox   string    `json:"mailbox"`
-	Name      string    `json:"name"`
-	IsDefault bool      `json:"is_default"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID         int       `json:"id"`
+	Server     string    `json:"server"`
+	SMTPServer string    `json:"smtp_server"`
+	Username   string    `json:"username"`
+	Password   string    `json:"password"`
+	Mailbox    string    `json:"mailbox"`
+	Name       string    `json:"name"`
+	IsDefault  bool      `json:"is_default"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
 }
 
 // CreateEmailServerConfig 创建邮件服务器配置
@@ -64,13 +66,14 @@ func (s *Setting) CreateEmailServerConfig(c *gin.Context) {
 	}
 
 	config := table.EmailServerConfig{
-		UserID:    user.ID,
-		Server:    req.Server,
-		Username:  req.Username,
-		Password:  req.Password, // SECURITY WARNING: Stored in plain text. Should be encrypted in production.
-		Mailbox:   req.Mailbox,
-		Name:      req.Name,
-		IsDefault: req.IsDefault,
+		UserID:     user.ID,
+		Server:     req.Server,
+		SMTPServer: req.SMTPServer,
+		Username:   req.Username,
+		Password:   req.Password, // SECURITY WARNING: Stored in plain text. Should be encrypted in production.
+		Mailbox:    req.Mailbox,
+		Name:       req.Name,
+		IsDefault:  req.IsDefault,
 	}
 
 	if err := s.db.Create(&config).Error; err != nil {
@@ -80,15 +83,16 @@ func (s *Setting) CreateEmailServerConfig(c *gin.Context) {
 	}
 
 	resp := EmailServerConfigResponse{
-		ID:        config.ID,
-		Server:    config.Server,
-		Username:  config.Username,
-		Password:  config.Password,
-		Mailbox:   config.Mailbox,
-		Name:      config.Name,
-		IsDefault: config.IsDefault,
-		CreatedAt: config.CreatedAt,
-		UpdatedAt: config.UpdatedAt,
+		ID:         config.ID,
+		Server:     config.Server,
+		SMTPServer: config.SMTPServer,
+		Username:   config.Username,
+		Password:   config.Password,
+		Mailbox:    config.Mailbox,
+		Name:       config.Name,
+		IsDefault:  config.IsDefault,
+		CreatedAt:  config.CreatedAt,
+		UpdatedAt:  config.UpdatedAt,
 	}
 
 	c.JSON(http.StatusCreated, resp)
@@ -122,15 +126,16 @@ func (s *Setting) ListEmailServerConfigs(c *gin.Context) {
 	for i := range configs {
 		cfg := configs[i]
 		item := EmailServerConfigResponse{
-			ID:        cfg.ID,
-			Server:    cfg.Server,
-			Username:  cfg.Username,
-			Password:  cfg.Password,
-			Mailbox:   cfg.Mailbox,
-			Name:      cfg.Name,
-			IsDefault: cfg.IsDefault,
-			CreatedAt: cfg.CreatedAt,
-			UpdatedAt: cfg.UpdatedAt,
+			ID:         cfg.ID,
+			Server:     cfg.Server,
+			SMTPServer: cfg.SMTPServer,
+			Username:   cfg.Username,
+			Password:   cfg.Password,
+			Mailbox:    cfg.Mailbox,
+			Name:       cfg.Name,
+			IsDefault:  cfg.IsDefault,
+			CreatedAt:  cfg.CreatedAt,
+			UpdatedAt:  cfg.UpdatedAt,
 		}
 		response = append(response, item)
 	}
@@ -170,15 +175,16 @@ func (s *Setting) GetEmailServerConfig(c *gin.Context) {
 	}
 
 	resp := EmailServerConfigResponse{
-		ID:        config.ID,
-		Server:    config.Server,
-		Username:  config.Username,
-		Password:  config.Password,
-		Mailbox:   config.Mailbox,
-		Name:      config.Name,
-		IsDefault: config.IsDefault,
-		CreatedAt: config.CreatedAt,
-		UpdatedAt: config.UpdatedAt,
+		ID:         config.ID,
+		Server:     config.Server,
+		SMTPServer: config.SMTPServer,
+		Username:   config.Username,
+		Password:   config.Password,
+		Mailbox:    config.Mailbox,
+		Name:       config.Name,
+		IsDefault:  config.IsDefault,
+		CreatedAt:  config.CreatedAt,
+		UpdatedAt:  config.UpdatedAt,
 	}
 
 	c.JSON(http.StatusOK, resp)
@@ -240,6 +246,7 @@ func (s *Setting) UpdateEmailServerConfig(c *gin.Context) {
 
 	// 更新配置
 	config.Server = req.Server
+	config.SMTPServer = req.SMTPServer
 	config.Username = req.Username
 	if req.Password != "" {
 		// Only update password if provided (SECURITY WARNING: Stored in plain text)
@@ -256,15 +263,16 @@ func (s *Setting) UpdateEmailServerConfig(c *gin.Context) {
 	}
 
 	resp := EmailServerConfigResponse{
-		ID:        config.ID,
-		Server:    config.Server,
-		Username:  config.Username,
-		Password:  config.Password,
-		Mailbox:   config.Mailbox,
-		Name:      config.Name,
-		IsDefault: config.IsDefault,
-		CreatedAt: config.CreatedAt,
-		UpdatedAt: config.UpdatedAt,
+		ID:         config.ID,
+		Server:     config.Server,
+		SMTPServer: config.SMTPServer,
+		Username:   config.Username,
+		Password:   config.Password,
+		Mailbox:    config.Mailbox,
+		Name:       config.Name,
+		IsDefault:  config.IsDefault,
+		CreatedAt:  config.CreatedAt,
+		UpdatedAt:  config.UpdatedAt,
 	}
 
 	c.JSON(http.StatusOK, resp)

--- a/internal/app/aiguide/table/table.go
+++ b/internal/app/aiguide/table/table.go
@@ -48,13 +48,14 @@ type Project struct {
 type EmailServerConfig struct {
 	Model
 
-	UserID    int    // 关联的用户 ID
-	Server    string `gorm:"not null"` // IMAP 服务器地址，例如: imap.gmail.com:993
-	Username  string `gorm:"not null"` // 邮箱账号
-	Password  string `gorm:"not null"` // 邮箱密码或应用专用密码（应加密存储）
-	Mailbox   string // 邮箱文件夹名称，默认为 INBOX
-	Name      string // 配置名称，用于用户识别多个邮箱
-	IsDefault bool   `gorm:"default:false"` // 是否为默认邮箱
+	UserID     int    // 关联的用户 ID
+	Server     string `gorm:"not null"` // IMAP 服务器地址，例如: imap.gmail.com:993
+	SMTPServer string // SMTP 服务器地址，例如: smtp.gmail.com:587
+	Username   string `gorm:"not null"` // 邮箱账号
+	Password   string `gorm:"not null"` // 邮箱密码或应用专用密码（应加密存储）
+	Mailbox    string // 邮箱文件夹名称，默认为 INBOX
+	Name       string // 配置名称，用于用户识别多个邮箱
+	IsDefault  bool   `gorm:"default:false"` // 是否为默认邮箱
 }
 
 // UserMemory 用户记忆，用于跨会话记住用户特征

--- a/internal/pkg/tools/email.go
+++ b/internal/pkg/tools/email.go
@@ -118,18 +118,17 @@ func querySingleServer(ctx context.Context, input EmailQueryInput) (*EmailQueryO
 	}
 
 	// 查找用户的邮件服务器配置
-	if err := tx.Where("user_id = ?", userID).Find(&emailServerConfigs).Error; err != nil {
+	if err := tx.Where("user_id = ?", userID).Order("is_default DESC, created_at DESC").Find(&emailServerConfigs).Error; err != nil {
 		slog.Error("tx.Find() error", "err", err)
 		return nil, fmt.Errorf("tx.Find() error, err = %w", err)
 	}
 
 	if len(emailServerConfigs) == 0 {
 		slog.Info("没有找到邮件服务器配置")
-		configURL := "http://localhost:3000/settings/email-server-configs"
 		return &EmailQueryOutput{
 			Success:   false,
 			Message:   "没有找到邮件服务器配置",
-			ConfigURL: configURL,
+			ConfigURL: emailServerConfigURL,
 		}, nil
 	}
 

--- a/internal/pkg/tools/email_test.go
+++ b/internal/pkg/tools/email_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/emersion/go-imap/v2"
@@ -14,6 +15,130 @@ func TestNewEmailQueryTool(t *testing.T) {
 
 	if tool == nil {
 		t.Fatal("NewEmailQueryTool() returned nil tool")
+	}
+}
+
+func TestNewSendEmailTool(t *testing.T) {
+	tool, err := NewSendEmailTool()
+	if err != nil {
+		t.Fatalf("NewSendEmailTool() failed: %v", err)
+	}
+
+	if tool == nil {
+		t.Fatal("NewSendEmailTool() returned nil tool")
+	}
+}
+
+func TestValidateSendEmailInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   SendEmailInput
+		wantErr bool
+	}{
+		{
+			name: "valid input",
+			input: SendEmailInput{
+				To:      []string{"Alice <alice@example.com>", "bob@example.com"},
+				Subject: "Status update",
+				Body:    "All good",
+			},
+		},
+		{
+			name: "missing recipients",
+			input: SendEmailInput{
+				Subject: "Status update",
+				Body:    "All good",
+			},
+		},
+		{
+			name: "invalid recipient",
+			input: SendEmailInput{
+				To:      []string{"invalid-email"},
+				Subject: "Status update",
+				Body:    "All good",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateSendEmailInput(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("validateSendEmailInput() error = nil, want non-nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("validateSendEmailInput() error = %v", err)
+			}
+			wantToLen := len(tt.input.To)
+			if len(got.To) != wantToLen {
+				t.Fatalf("len(got.To) = %d, want %d", len(got.To), wantToLen)
+			}
+		})
+	}
+}
+
+func TestPopulateDefaultRecipient(t *testing.T) {
+	input := &SendEmailInput{Subject: "Status update", Body: "All good"}
+	defaulted, err := populateDefaultRecipient(input, "sender@example.com")
+	if err != nil {
+		t.Fatalf("populateDefaultRecipient() error = %v", err)
+	}
+	if !defaulted {
+		t.Fatal("populateDefaultRecipient() defaulted = false, want true")
+	}
+	if len(input.To) != 1 || input.To[0] != "sender@example.com" {
+		t.Fatalf("populateDefaultRecipient() To = %v, want [sender@example.com]", input.To)
+	}
+}
+
+func TestPopulateDefaultRecipientKeepsExistingTo(t *testing.T) {
+	input := &SendEmailInput{To: []string{"target@example.com"}, Subject: "Status update", Body: "All good"}
+	defaulted, err := populateDefaultRecipient(input, "sender@example.com")
+	if err != nil {
+		t.Fatalf("populateDefaultRecipient() error = %v", err)
+	}
+	if defaulted {
+		t.Fatal("populateDefaultRecipient() defaulted = true, want false")
+	}
+	if len(input.To) != 1 || input.To[0] != "target@example.com" {
+		t.Fatalf("populateDefaultRecipient() To = %v, want [target@example.com]", input.To)
+	}
+}
+
+func TestBuildEmailMessage(t *testing.T) {
+	message, err := buildEmailMessage("sender@example.com", "测试发件人", SendEmailInput{
+		To:      []string{"to@example.com"},
+		Cc:      []string{"cc@example.com"},
+		Bcc:     []string{"bcc@example.com"},
+		Subject: "项目进展",
+		Body:    "第一行\n第二行",
+	}, []string{"to@example.com", "cc@example.com", "bcc@example.com"})
+	if err != nil {
+		t.Fatalf("buildEmailMessage() error = %v", err)
+	}
+
+	content := string(message)
+	checks := []string{
+		"From: =?UTF-8?",
+		"To: to@example.com",
+		"Cc: cc@example.com",
+		"Subject: =?UTF-8?",
+		"Content-Type: text/plain; charset=UTF-8",
+		"第一行\r\n第二行",
+	}
+	for _, check := range checks {
+		if !strings.Contains(content, check) {
+			t.Fatalf("buildEmailMessage() missing %q in %q", check, content)
+		}
+	}
+
+	if strings.Contains(content, "Bcc:") {
+		t.Fatalf("buildEmailMessage() should not include Bcc header: %q", content)
 	}
 }
 

--- a/internal/pkg/tools/send_email.go
+++ b/internal/pkg/tools/send_email.go
@@ -1,0 +1,425 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"mime"
+	"net/mail"
+	"net/smtp"
+	"sort"
+	"strings"
+
+	"aiguide/internal/app/aiguide/table"
+	"aiguide/internal/pkg/middleware"
+
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+)
+
+const emailServerConfigURL = "http://localhost:3000/settings/email-server-configs"
+
+type SendEmailInput struct {
+	ConfigName string   `json:"config_name,omitempty" jsonschema:"可选，指定使用的邮件配置名称；不填时优先使用默认配置"`
+	To         []string `json:"to,omitempty" jsonschema:"收件人邮箱地址列表；留空时默认发送给发件人自己"`
+	Cc         []string `json:"cc,omitempty" jsonschema:"抄送邮箱地址列表（可选）"`
+	Bcc        []string `json:"bcc,omitempty" jsonschema:"密送邮箱地址列表（可选）"`
+	Subject    string   `json:"subject" jsonschema:"邮件主题"`
+	Body       string   `json:"body" jsonschema:"邮件正文内容"`
+	IsHTML     bool     `json:"is_html,omitempty" jsonschema:"正文是否为 HTML，默认为纯文本"`
+	FromName   string   `json:"from_name,omitempty" jsonschema:"可选，自定义发件人名称；不填则使用配置名称"`
+}
+
+type SendEmailOutput struct {
+	Success     bool     `json:"success"`
+	Message     string   `json:"message,omitempty"`
+	Error       string   `json:"error,omitempty"`
+	UsedConfig  string   `json:"used_config,omitempty"`
+	Recipients  []string `json:"recipients,omitempty"`
+	ConfigURL   string   `json:"config_url,omitempty"`
+	NeedsConfig bool     `json:"needs_config,omitempty"`
+}
+
+func NewSendEmailTool() (tool.Tool, error) {
+	config := functiontool.Config{
+		Name:        "send_email",
+		Description: "发送邮件。使用用户已配置的 SMTP 服务器向一个或多个收件人发送纯文本或 HTML 邮件。适合草拟后正式发出通知、回复或汇报。",
+	}
+
+	handler := func(ctx tool.Context, input SendEmailInput) (*SendEmailOutput, error) {
+		return sendEmail(ctx, input)
+	}
+
+	return functiontool.New(config, handler)
+}
+
+func sendEmail(ctx context.Context, input SendEmailInput) (*SendEmailOutput, error) {
+	validatedInput, err := validateSendEmailInput(input)
+	if err != nil {
+		slog.Error(err.Error())
+		return &SendEmailOutput{
+			Success: false,
+			Error:   err.Error(),
+		}, nil
+	}
+
+	emailServerConfig, output, err := loadEmailServerConfigForSending(ctx, validatedInput.ConfigName)
+	if err != nil {
+		return nil, err
+	}
+	if output != nil {
+		return output, nil
+	}
+
+	fromName := validatedInput.FromName
+	if fromName == "" {
+		fromName = emailServerConfig.Name
+	}
+
+	defaultedToSelf, err := populateDefaultRecipient(&validatedInput, emailServerConfig.Username)
+	if err != nil {
+		slog.Error("populateDefaultRecipient() error", "username", emailServerConfig.Username, "err", err)
+		return &SendEmailOutput{
+			Success:    false,
+			Error:      fmt.Sprintf("默认收件人无效: %v", err),
+			UsedConfig: emailServerConfig.Name,
+		}, nil
+	}
+
+	recipients := append(append(append([]string{}, validatedInput.To...), validatedInput.Cc...), validatedInput.Bcc...)
+	slog.Info("开始发送邮件",
+		"config_name", emailServerConfig.Name,
+		"smtp_server", emailServerConfig.SMTPServer,
+		"default_to_self", defaultedToSelf,
+		"to_count", len(validatedInput.To),
+		"cc_count", len(validatedInput.Cc),
+		"bcc_count", len(validatedInput.Bcc),
+		"recipient_count", len(recipients),
+		"subject", validatedInput.Subject,
+	)
+
+	message, err := buildEmailMessage(emailServerConfig.Username, fromName, validatedInput, recipients)
+	if err != nil {
+		slog.Error("buildEmailMessage() error", "err", err)
+		return nil, fmt.Errorf("buildEmailMessage() error, err = %w", err)
+	}
+
+	if err := sendSMTPMessage(emailServerConfig.SMTPServer, emailServerConfig.Username, emailServerConfig.Password, recipients, message); err != nil {
+		slog.Error("sendSMTPMessage() error", "smtp_server", emailServerConfig.SMTPServer, "config_name", emailServerConfig.Name, "err", err)
+		return &SendEmailOutput{
+			Success:    false,
+			Error:      fmt.Sprintf("发送邮件失败: %v", err),
+			UsedConfig: emailServerConfig.Name,
+		}, nil
+	}
+
+	slog.Info("邮件发送成功",
+		"config_name", emailServerConfig.Name,
+		"smtp_server", emailServerConfig.SMTPServer,
+		"default_to_self", defaultedToSelf,
+		"recipient_count", len(recipients),
+		"subject", validatedInput.Subject,
+	)
+
+	return &SendEmailOutput{
+		Success:    true,
+		Message:    fmt.Sprintf("邮件已成功发送给 %d 位收件人", len(recipients)),
+		UsedConfig: emailServerConfig.Name,
+		Recipients: recipients,
+	}, nil
+}
+
+func validateSendEmailInput(input SendEmailInput) (SendEmailInput, error) {
+	input.ConfigName = strings.TrimSpace(input.ConfigName)
+	input.Subject = strings.TrimSpace(input.Subject)
+	input.Body = strings.TrimSpace(input.Body)
+	input.FromName = strings.TrimSpace(input.FromName)
+
+	if input.Subject == "" {
+		return SendEmailInput{}, fmt.Errorf("邮件主题不能为空")
+	}
+	if input.Body == "" {
+		return SendEmailInput{}, fmt.Errorf("邮件正文不能为空")
+	}
+
+	var err error
+	input.To, err = normalizeEmailAddresses(input.To)
+	if err != nil {
+		return SendEmailInput{}, fmt.Errorf("收件人地址无效: %w", err)
+	}
+	input.Cc, err = normalizeEmailAddresses(input.Cc)
+	if err != nil {
+		return SendEmailInput{}, fmt.Errorf("抄送地址无效: %w", err)
+	}
+	input.Bcc, err = normalizeEmailAddresses(input.Bcc)
+	if err != nil {
+		return SendEmailInput{}, fmt.Errorf("密送地址无效: %w", err)
+	}
+
+	return input, nil
+}
+
+func populateDefaultRecipient(input *SendEmailInput, senderAddress string) (bool, error) {
+	if len(input.To) > 0 {
+		return false, nil
+	}
+
+	defaultRecipients, err := normalizeEmailAddresses([]string{senderAddress})
+	if err != nil {
+		return false, err
+	}
+	if len(defaultRecipients) == 0 {
+		return false, fmt.Errorf("发件人邮箱不能为空")
+	}
+
+	input.To = defaultRecipients
+	return true, nil
+}
+
+func normalizeEmailAddresses(addresses []string) ([]string, error) {
+	if len(addresses) == 0 {
+		return nil, nil
+	}
+
+	normalized := make([]string, 0, len(addresses))
+	seen := make(map[string]struct{}, len(addresses))
+	for _, rawAddress := range addresses {
+		parsedAddress, err := mail.ParseAddress(strings.TrimSpace(rawAddress))
+		if err != nil {
+			return nil, fmt.Errorf("%q: %w", rawAddress, err)
+		}
+		address := strings.ToLower(strings.TrimSpace(parsedAddress.Address))
+		if _, exists := seen[address]; exists {
+			continue
+		}
+		seen[address] = struct{}{}
+		normalized = append(normalized, address)
+	}
+
+	sort.Strings(normalized)
+	return normalized, nil
+}
+
+func loadEmailServerConfigForSending(ctx context.Context, configName string) (*table.EmailServerConfig, *SendEmailOutput, error) {
+	tx, ok := middleware.GetTx(ctx)
+	if !ok {
+		slog.Error("没有从 context 中找到 db")
+		return nil, &SendEmailOutput{
+			Success: false,
+			Error:   "没有从 context 中找到 db",
+		}, nil
+	}
+
+	userID, ok := middleware.GetUserID(ctx)
+	if !ok {
+		slog.Error("没有从 context 中找到 user id")
+		return nil, &SendEmailOutput{
+			Success: false,
+			Error:   "没有从 context 中找到 user id",
+		}, nil
+	}
+
+	var emailServerConfigs []*table.EmailServerConfig
+	query := tx.Where("user_id = ?", userID).Order("is_default DESC, created_at DESC")
+	if configName != "" {
+		query = query.Where("name = ?", configName)
+	}
+	if err := query.Find(&emailServerConfigs).Error; err != nil {
+		slog.Error("query.Find() error", "user_id", userID, "config_name", configName, "err", err)
+		return nil, nil, fmt.Errorf("query.Find() error, err = %w", err)
+	}
+
+	if len(emailServerConfigs) == 0 {
+		message := "没有找到邮件服务器配置"
+		if configName != "" {
+			message = fmt.Sprintf("没有找到名为 %q 的邮件配置", configName)
+		}
+		return nil, &SendEmailOutput{
+			Success:     false,
+			Message:     message,
+			ConfigURL:   emailServerConfigURL,
+			NeedsConfig: true,
+		}, nil
+	}
+
+	emailServerConfig := emailServerConfigs[0]
+	if strings.TrimSpace(emailServerConfig.SMTPServer) == "" {
+		return nil, &SendEmailOutput{
+			Success:     false,
+			Message:     fmt.Sprintf("邮件配置 %q 尚未设置 SMTP 服务器，暂时无法发送邮件", emailServerConfig.Name),
+			UsedConfig:  emailServerConfig.Name,
+			ConfigURL:   emailServerConfigURL,
+			NeedsConfig: true,
+		}, nil
+	}
+
+	return emailServerConfig, nil, nil
+}
+
+func buildEmailMessage(fromAddress, fromName string, input SendEmailInput, recipients []string) ([]byte, error) {
+	var buffer bytes.Buffer
+
+	fromHeader := formatHeaderAddress(fromName, fromAddress)
+	if fromHeader == "" {
+		return nil, fmt.Errorf("发件人地址不能为空")
+	}
+
+	headers := []string{
+		fmt.Sprintf("From: %s", fromHeader),
+		fmt.Sprintf("To: %s", strings.Join(input.To, ", ")),
+		fmt.Sprintf("Subject: %s", encodeHeader(input.Subject)),
+		"MIME-Version: 1.0",
+	}
+	if len(input.Cc) > 0 {
+		headers = append(headers, fmt.Sprintf("Cc: %s", strings.Join(input.Cc, ", ")))
+	}
+	contentType := "text/plain; charset=UTF-8"
+	if input.IsHTML {
+		contentType = "text/html; charset=UTF-8"
+	}
+	headers = append(headers,
+		fmt.Sprintf("Content-Type: %s", contentType),
+		"Content-Transfer-Encoding: 8bit",
+	)
+
+	for _, header := range headers {
+		buffer.WriteString(header)
+		buffer.WriteString("\r\n")
+	}
+	buffer.WriteString("\r\n")
+	buffer.WriteString(normalizeCRLF(input.Body))
+	if !strings.HasSuffix(buffer.String(), "\r\n") {
+		buffer.WriteString("\r\n")
+	}
+
+	if len(recipients) == 0 {
+		return nil, fmt.Errorf("收件人列表不能为空")
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func sendSMTPMessage(serverAddr, username, password string, recipients []string, message []byte) error {
+	host := parseServerName(serverAddr)
+	if host == "" {
+		slog.Error("SMTP 服务器地址不能为空")
+		return fmt.Errorf("SMTP 服务器地址不能为空")
+	}
+
+	if strings.HasSuffix(serverAddr, ":465") {
+		conn, err := tls.Dial("tcp", serverAddr, &tls.Config{ServerName: host})
+		if err != nil {
+			slog.Error("tls.Dial() error", "smtp_server", serverAddr, "err", err)
+			return fmt.Errorf("连接 SMTP 服务器失败: %w", err)
+		}
+
+		client, err := smtp.NewClient(conn, host)
+		if err != nil {
+			conn.Close()
+			slog.Error("smtp.NewClient() error", "smtp_server", serverAddr, "err", err)
+			return fmt.Errorf("初始化 SMTP 客户端失败: %w", err)
+		}
+
+		return sendSMTPWithClient(client, host, username, password, recipients, message)
+	}
+
+	client, err := smtp.Dial(serverAddr)
+	if err != nil {
+		slog.Error("smtp.Dial() error", "smtp_server", serverAddr, "err", err)
+		return fmt.Errorf("连接 SMTP 服务器失败: %w", err)
+	}
+
+	if ok, _ := client.Extension("STARTTLS"); ok {
+		if err := client.StartTLS(&tls.Config{ServerName: host}); err != nil {
+			client.Close()
+			slog.Error("client.StartTLS() error", "smtp_server", serverAddr, "err", err)
+			return fmt.Errorf("启动 SMTP TLS 失败: %w", err)
+		}
+	}
+
+	return sendSMTPWithClient(client, host, username, password, recipients, message)
+}
+
+func sendSMTPWithClient(client *smtp.Client, host, username, password string, recipients []string, message []byte) error {
+	defer client.Close()
+
+	if ok, _ := client.Extension("AUTH"); ok && username != "" {
+		if err := client.Auth(smtp.PlainAuth("", username, password, host)); err != nil {
+			slog.Error("client.Auth() error", "smtp_host", host, "username", username, "err", err)
+			return fmt.Errorf("SMTP 认证失败: %w", err)
+		}
+	}
+
+	if err := client.Mail(username); err != nil {
+		slog.Error("client.Mail() error", "from", username, "err", err)
+		return fmt.Errorf("设置发件人失败: %w", err)
+	}
+
+	for _, recipient := range recipients {
+		if err := client.Rcpt(recipient); err != nil {
+			slog.Error("client.Rcpt() error", "recipient", recipient, "err", err)
+			return fmt.Errorf("添加收件人 %s 失败: %w", recipient, err)
+		}
+	}
+
+	writer, err := client.Data()
+	if err != nil {
+		slog.Error("client.Data() error", "err", err)
+		return fmt.Errorf("创建邮件数据流失败: %w", err)
+	}
+
+	if _, err := writer.Write(message); err != nil {
+		writer.Close()
+		slog.Error("writer.Write() error", "err", err)
+		return fmt.Errorf("写入邮件内容失败: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		slog.Error("writer.Close() error", "err", err)
+		return fmt.Errorf("完成邮件写入失败: %w", err)
+	}
+
+	if err := client.Quit(); err != nil {
+		slog.Error("client.Quit() error", "err", err)
+		return fmt.Errorf("结束 SMTP 会话失败: %w", err)
+	}
+
+	return nil
+}
+
+func formatHeaderAddress(name, address string) string {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return ""
+	}
+	if name == "" {
+		return address
+	}
+	if isASCII(name) {
+		return (&mail.Address{Name: name, Address: address}).String()
+	}
+	return fmt.Sprintf("%s <%s>", mime.QEncoding.Encode("UTF-8", name), address)
+}
+
+func encodeHeader(value string) string {
+	if isASCII(value) {
+		return value
+	}
+	return mime.QEncoding.Encode("UTF-8", value)
+}
+
+func isASCII(value string) bool {
+	for _, r := range value {
+		if r > 127 {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeCRLF(body string) string {
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	body = strings.ReplaceAll(body, "\r", "\n")
+	return strings.ReplaceAll(body, "\n", "\r\n")
+}


### PR DESCRIPTION
## Summary
- add an executor `send_email` tool with SMTP support, default-to-self recipient behavior, and structured send logs
- extend email server configs and settings UI to store/display optional SMTP server information
- replace the browser delete confirm with a custom confirmation modal in the email settings page

## Testing
- go test ./internal/pkg/tools ./internal/app/aiguide/assistant
- pnpm --dir frontend lint