### PR TITLE
fix: preserve executor tool calls in chat UI

### DIFF
--- a/frontend/app/chat/[sessionId]/page.tsx
+++ b/frontend/app/chat/[sessionId]/page.tsx
@@ -518,6 +518,15 @@ export default function ChatPage() {
         if (msg.images && msg.images.length > 0) {
           merged.images = [...(merged.images || []), ...(msg.images || [])];
         }
+        if (msg.fileNames && msg.fileNames.length > 0) {
+          merged.fileNames = [...(merged.fileNames || []), ...msg.fileNames];
+        }
+        if (msg.toolCalls && msg.toolCalls.length > 0) {
+          merged.toolCalls = [...(merged.toolCalls || []), ...msg.toolCalls];
+        }
+        if (msg.author) {
+          merged.author = msg.author;
+        }
         merged.isStreaming = last.isStreaming || msg.isStreaming;
 
         result[result.length - 1] = merged;


### PR DESCRIPTION
## Summary
- preserve `toolCalls`, `fileNames`, and `author` when merging consecutive assistant messages in the chat UI
- fix cases where the root agent's `transfer_to_agent` event hid later executor tool calls from the page
- keep the streamed tool activity display aligned with the actual SSE events emitted by the backend

## Validation
- `pnpm lint`