### PR TITLE
feat(ssh): add SSH execute tool with password and public-key auth

### DIFF
--- a/frontend/app/components/SessionSidebar.tsx
+++ b/frontend/app/components/SessionSidebar.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, memo, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/app/components/ui/button';
-import { Plus, ChevronLeft, ChevronRight, Trash2, LogOut, FolderOpen, MoreHorizontal, Pencil, Brain, Share2, Gamepad2 } from 'lucide-react';
+import { Plus, ChevronLeft, ChevronRight, Trash2, LogOut, FolderOpen, MoreHorizontal, Pencil, Brain, Share2, Gamepad2, Terminal } from 'lucide-react';
 import { cn } from '@/app/lib/utils';
 import { useAuth } from '@/app/contexts/AuthContext';
 import { Avatar, AvatarFallback, AvatarImage } from '@/app/components/ui/avatar';
@@ -161,6 +161,13 @@ const SessionSidebar = memo(({
 
   const handleMemoryCenterClick = useCallback(() => {
     router.push('/memory');
+    if (onMobileToggle && isMobileOpen) {
+      onMobileToggle();
+    }
+  }, [isMobileOpen, onMobileToggle, router]);
+
+  const handleSSHServersClick = useCallback(() => {
+    router.push('/settings/ssh-servers');
     if (onMobileToggle && isMobileOpen) {
       onMobileToggle();
     }
@@ -507,6 +514,13 @@ const SessionSidebar = memo(({
                 >
                   <Brain className="mr-2 h-4 w-4" />
                   <span>记忆中心</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="cursor-pointer"
+                  onClick={handleSSHServersClick}
+                >
+                  <Terminal className="mr-2 h-4 w-4" />
+                  <span>SSH Servers</span>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem

--- a/frontend/app/settings/ssh-servers/page.tsx
+++ b/frontend/app/settings/ssh-servers/page.tsx
@@ -1,0 +1,693 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/app/contexts/AuthContext';
+import { Button } from '@/app/components/ui/button';
+import { Input } from '@/app/components/ui/input';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/app/components/ui/card';
+import { Alert, AlertDescription } from '@/app/components/ui/alert';
+import {
+  AlertTriangle,
+  Plus,
+  Trash2,
+  Edit2,
+  Check,
+  X,
+  Terminal,
+  ArrowLeft,
+  Eye,
+  EyeOff,
+} from 'lucide-react';
+
+type AuthMethod = 'password' | 'key';
+
+interface SSHServerConfig {
+  id: number;
+  name: string;
+  host: string;
+  port: number;
+  username: string;
+  auth_method: AuthMethod;
+  password?: string;
+  private_key?: string;
+  passphrase?: string;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface FormData {
+  name: string;
+  host: string;
+  port: number;
+  username: string;
+  auth_method: AuthMethod;
+  password: string;
+  private_key: string;
+  passphrase: string;
+  is_default: boolean;
+}
+
+type ToastType = 'success' | 'error' | 'info';
+
+interface ToastMessage {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+const DEFAULT_FORM: FormData = {
+  name: '',
+  host: '',
+  port: 22,
+  username: '',
+  auth_method: 'password',
+  password: '',
+  private_key: '',
+  passphrase: '',
+  is_default: false,
+};
+
+export default function SSHServersPage() {
+  const router = useRouter();
+  const { user, loading } = useAuth();
+  const [configs, setConfigs] = useState<SSHServerConfig[]>([]);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<SSHServerConfig | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showPassphrase, setShowPassphrase] = useState(false);
+  const [formData, setFormData] = useState<FormData>(DEFAULT_FORM);
+  const [isLoading, setIsLoading] = useState(false);
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  const toastId = useRef(0);
+
+  const notify = useCallback((message: string, type: ToastType = 'info') => {
+    const id = toastId.current++;
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 3200);
+  }, []);
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push('/login');
+    }
+  }, [user, loading, router]);
+
+  useEffect(() => {
+    if (!deleteTarget) {
+      return;
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && deletingId === null) {
+        setDeleteTarget(null);
+      }
+    };
+
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, [deleteTarget, deletingId]);
+
+  const loadConfigs = useCallback(async () => {
+    try {
+      const response = await fetch('/api/ssh_server_configs', {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setConfigs(data.configs || []);
+      } else {
+        notify('Failed to load SSH server configs', 'error');
+      }
+    } catch (err) {
+      notify('Failed to load SSH server configs: ' + (err as Error).message, 'error');
+    }
+  }, [notify]);
+
+  useEffect(() => {
+    if (user) {
+      loadConfigs();
+    }
+  }, [loadConfigs, user]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+
+    try {
+      const url = editingId
+        ? `/api/ssh_server_configs/${editingId}`
+        : '/api/ssh_server_configs';
+      const method = editingId ? 'PUT' : 'POST';
+
+      const response = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(formData),
+      });
+
+      if (response.ok) {
+        notify(editingId ? 'Updated successfully' : 'Added successfully', 'success');
+        setShowForm(false);
+        setEditingId(null);
+        resetForm();
+        await loadConfigs();
+      } else {
+        const data = await response.json();
+        notify(data.error || 'Operation failed', 'error');
+      }
+    } catch (err) {
+      notify('Operation failed: ' + (err as Error).message, 'error');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleEdit = async (config: SSHServerConfig) => {
+    setIsLoading(true);
+    setShowPassword(false);
+    setShowPassphrase(false);
+
+    try {
+      const response = await fetch(`/api/ssh_server_configs/${config.id}`, {
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        notify(data.error || 'Failed to load config', 'error');
+        return;
+      }
+
+      const detail: SSHServerConfig = await response.json();
+
+      setFormData({
+        name: detail.name,
+        host: detail.host,
+        port: detail.port || 22,
+        username: detail.username,
+        auth_method: detail.auth_method || 'password',
+        password: detail.password || '',
+        private_key: detail.private_key || '',
+        passphrase: detail.passphrase || '',
+        is_default: detail.is_default,
+      });
+
+      setEditingId(detail.id);
+      setShowForm(true);
+    } catch (err) {
+      notify('Failed to load config: ' + (err as Error).message, 'error');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDelete = (config: SSHServerConfig) => {
+    setDeleteTarget(config);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) {
+      return;
+    }
+
+    setDeletingId(deleteTarget.id);
+    try {
+      const response = await fetch(`/api/ssh_server_configs/${deleteTarget.id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+
+      if (response.ok) {
+        notify('Deleted successfully', 'success');
+        setDeleteTarget(null);
+        await loadConfigs();
+      } else {
+        const data = await response.json();
+        notify(data.error || 'Delete failed', 'error');
+      }
+    } catch (err) {
+      notify('Delete failed: ' + (err as Error).message, 'error');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const resetForm = () => {
+    setFormData(DEFAULT_FORM);
+    setEditingId(null);
+    setShowPassword(false);
+    setShowPassphrase(false);
+  };
+
+  const handleCancel = () => {
+    setShowForm(false);
+    resetForm();
+  };
+
+  const handleAuthMethodChange = (method: AuthMethod) => {
+    setFormData((prev) => ({ ...prev, auth_method: method, password: '', private_key: '', passphrase: '' }));
+    setShowPassword(false);
+    setShowPassphrase(false);
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Delete confirmation modal */}
+      {deleteTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4 backdrop-blur-sm">
+          <div className="w-full max-w-md overflow-hidden rounded-2xl border border-red-100 bg-white shadow-2xl">
+            <div className="bg-[linear-gradient(135deg,#fff1f2_0%,#ffffff_65%)] px-6 py-5">
+              <div className="flex items-start gap-4">
+                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-red-100 text-red-600 shadow-sm">
+                  <AlertTriangle className="h-5 w-5" />
+                </div>
+                <div className="space-y-1">
+                  <h2 className="text-lg font-semibold text-slate-900">
+                    Delete SSH server config?
+                  </h2>
+                  <p className="text-sm leading-6 text-slate-600">
+                    This removes the SSH connection for{' '}
+                    <span className="font-medium text-slate-900">{deleteTarget.name}</span>.
+                    The agent will no longer be able to run commands on this server.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-4 px-6 py-5">
+              <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+                <div className="font-medium text-slate-900">{deleteTarget.username}@{deleteTarget.host}</div>
+                <div className="mt-1">Port: {deleteTarget.port}</div>
+              </div>
+
+              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setDeleteTarget(null)}
+                  disabled={deletingId !== null}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={confirmDelete}
+                  disabled={deletingId !== null}
+                  className="min-w-28"
+                >
+                  {deletingId === deleteTarget.id ? 'Deleting...' : 'Confirm delete'}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        {/* Page header */}
+        <div className="mb-6 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => router.push('/chat')}
+            >
+              <ArrowLeft className="h-5 w-5" />
+            </Button>
+            <div>
+              <h1 className="text-3xl font-bold">SSH Server Configs</h1>
+              <p className="text-muted-foreground mt-1">
+                Manage SSH connections the agent can use to run commands
+              </p>
+            </div>
+          </div>
+          {!showForm && (
+            <Button onClick={() => setShowForm(true)}>
+              <Plus className="h-4 w-4 mr-2" />
+              Add server
+            </Button>
+          )}
+        </div>
+
+        <Alert className="mb-4 border-yellow-500 bg-yellow-50 dark:bg-yellow-950">
+          <AlertDescription className="text-yellow-800 dark:text-yellow-200">
+            <strong>Security notice:</strong> Credentials are stored in plain text. Use a
+            dedicated low-privilege account and avoid reusing important passwords or keys.
+          </AlertDescription>
+        </Alert>
+
+        {/* Toast notifications */}
+        <div className="fixed top-4 right-4 z-50 flex flex-col gap-2 w-80">
+          {toasts.map((toast) => {
+            const isSuccess = toast.type === 'success';
+            const isError = toast.type === 'error';
+            const base = 'rounded-md px-4 py-3 shadow-lg text-sm flex items-start gap-2 border';
+            const theme = isSuccess
+              ? 'bg-green-50 text-green-800 border-green-200'
+              : isError
+                ? 'bg-red-50 text-red-800 border-red-200'
+                : 'bg-blue-50 text-blue-800 border-blue-200';
+            return (
+              <div key={toast.id} className={`${base} ${theme}`}>
+                <span className="font-semibold">
+                  {isSuccess ? 'Success' : isError ? 'Error' : 'Info'}
+                </span>
+                <span className="flex-1">{toast.message}</span>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Add / Edit form */}
+        {showForm && (
+          <Card className="mb-6">
+            <CardHeader>
+              <CardTitle>{editingId ? 'Edit' : 'Add'} SSH server</CardTitle>
+              <CardDescription>
+                Enter the connection details. The agent will use these credentials to run shell commands.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium mb-2">
+                    Config name *
+                  </label>
+                  <Input
+                    type="text"
+                    value={formData.name}
+                    onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                    placeholder="e.g. My dev server"
+                    required
+                  />
+                </div>
+
+                <div className="grid grid-cols-3 gap-4">
+                  <div className="col-span-2">
+                    <label className="block text-sm font-medium mb-2">
+                      Host *
+                    </label>
+                    <Input
+                      type="text"
+                      value={formData.host}
+                      onChange={(e) => setFormData({ ...formData, host: e.target.value })}
+                      placeholder="e.g. 192.168.1.10 or example.com"
+                      required
+                    />
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Hostname or IP address of the remote machine
+                    </p>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-2">
+                      Port *
+                    </label>
+                    <Input
+                      type="number"
+                      min={1}
+                      max={65535}
+                      value={formData.port}
+                      onChange={(e) =>
+                        setFormData({ ...formData, port: parseInt(e.target.value, 10) || 22 })
+                      }
+                      placeholder="22"
+                      required
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium mb-2">
+                    Username *
+                  </label>
+                  <Input
+                    type="text"
+                    value={formData.username}
+                    onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+                    placeholder="e.g. ubuntu"
+                    required
+                  />
+                </div>
+
+                {/* Auth method toggle */}
+                <div>
+                  <label className="block text-sm font-medium mb-2">
+                    Authentication method
+                  </label>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleAuthMethodChange('password')}
+                      className={`flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors ${
+                        formData.auth_method === 'password'
+                          ? 'border-primary bg-primary text-primary-foreground'
+                          : 'border-input bg-background hover:bg-accent hover:text-accent-foreground'
+                      }`}
+                    >
+                      Password
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleAuthMethodChange('key')}
+                      className={`flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors ${
+                        formData.auth_method === 'key'
+                          ? 'border-primary bg-primary text-primary-foreground'
+                          : 'border-input bg-background hover:bg-accent hover:text-accent-foreground'
+                      }`}
+                    >
+                      Public key
+                    </button>
+                  </div>
+                </div>
+
+                {/* Password field */}
+                {formData.auth_method === 'password' && (
+                  <div>
+                    <label className="block text-sm font-medium mb-2">
+                      Password{!editingId && ' *'}
+                    </label>
+                    <div className="relative">
+                      <Input
+                        type={showPassword ? 'text' : 'password'}
+                        value={formData.password}
+                        onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                        placeholder={editingId ? 'Leave blank to keep current password' : 'SSH password'}
+                        required={!editingId}
+                        className="pr-10"
+                      />
+                      <button
+                        type="button"
+                        className="absolute inset-y-0 right-0 px-3 flex items-center text-muted-foreground hover:text-foreground"
+                        onClick={() => setShowPassword((v) => !v)}
+                      >
+                        {showPassword ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Private key + passphrase fields */}
+                {formData.auth_method === 'key' && (
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-sm font-medium mb-2">
+                        Private key (PEM){!editingId && ' *'}
+                      </label>
+                      <textarea
+                        value={formData.private_key}
+                        onChange={(e) => setFormData({ ...formData, private_key: e.target.value })}
+                        placeholder={
+                          editingId
+                            ? 'Leave blank to keep current key'
+                            : '-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----'
+                        }
+                        required={!editingId}
+                        rows={6}
+                        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+                      />
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Paste your PEM-encoded private key (RSA, ECDSA, or Ed25519).
+                      </p>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium mb-2">
+                        Passphrase <span className="text-muted-foreground font-normal">(optional)</span>
+                      </label>
+                      <div className="relative">
+                        <Input
+                          type={showPassphrase ? 'text' : 'password'}
+                          value={formData.passphrase}
+                          onChange={(e) => setFormData({ ...formData, passphrase: e.target.value })}
+                          placeholder={editingId ? 'Leave blank to keep current passphrase' : 'Key passphrase (if encrypted)'}
+                          className="pr-10"
+                        />
+                        <button
+                          type="button"
+                          className="absolute inset-y-0 right-0 px-3 flex items-center text-muted-foreground hover:text-foreground"
+                          onClick={() => setShowPassphrase((v) => !v)}
+                        >
+                          {showPassphrase ? (
+                            <EyeOff className="h-4 w-4" />
+                          ) : (
+                            <Eye className="h-4 w-4" />
+                          )}
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    id="is_default"
+                    checked={formData.is_default}
+                    onChange={(e) => setFormData({ ...formData, is_default: e.target.checked })}
+                    className="rounded"
+                  />
+                  <label htmlFor="is_default" className="text-sm">
+                    Set as default server
+                  </label>
+                </div>
+
+                <div className="flex gap-2 pt-4">
+                  <Button type="submit" disabled={isLoading}>
+                    {isLoading ? (
+                      <>
+                        <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2"></div>
+                        Saving...
+                      </>
+                    ) : (
+                      <>
+                        <Check className="h-4 w-4 mr-2" />
+                        {editingId ? 'Update' : 'Add'}
+                      </>
+                    )}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleCancel}
+                    disabled={isLoading}
+                  >
+                    <X className="h-4 w-4 mr-2" />
+                    Cancel
+                  </Button>
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Config list */}
+        <div className="space-y-4">
+          {configs.length === 0 ? (
+            <Card>
+              <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+                <Terminal className="h-12 w-12 text-muted-foreground mb-4" />
+                <h3 className="text-lg font-semibold mb-2">No SSH servers configured</h3>
+                <p className="text-muted-foreground mb-4">
+                  Add an SSH server so the agent can run shell commands on your machines.
+                </p>
+                {!showForm && (
+                  <Button onClick={() => setShowForm(true)}>
+                    <Plus className="h-4 w-4 mr-2" />
+                    Add your first server
+                  </Button>
+                )}
+              </CardContent>
+            </Card>
+          ) : (
+            configs.map((config) => (
+              <Card key={config.id}>
+                <CardHeader>
+                  <div className="flex items-start justify-between">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2">
+                        <CardTitle className="text-lg">{config.name}</CardTitle>
+                        {config.is_default && (
+                          <span className="text-xs px-2 py-1 bg-primary text-primary-foreground rounded">
+                            Default
+                          </span>
+                        )}
+                      </div>
+                      <CardDescription className="mt-1">
+                        {config.username}@{config.host}
+                      </CardDescription>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleEdit(config)}
+                      >
+                        <Edit2 className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleDelete(config)}
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-2 gap-4 text-sm">
+                    <div>
+                      <span className="text-muted-foreground">Host:</span>
+                      <span className="ml-2">{config.host}</span>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">Port:</span>
+                      <span className="ml-2">{config.port}</span>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">Username:</span>
+                      <span className="ml-2">{config.username}</span>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">Auth:</span>
+                      <span className="ml-2 capitalize">
+                        {config.auth_method === 'key' ? 'Public key' : 'Password'}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="mt-2 text-xs text-muted-foreground">
+                    Added {new Date(config.created_at).toLocaleString()}
+                  </div>
+                </CardContent>
+              </Card>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/internal/app/aiguide/assistant/executor_agent.go
+++ b/internal/app/aiguide/assistant/executor_agent.go
@@ -127,6 +127,11 @@ func NewExecutorAgent(config *ExecutorAgentConfig) (agent.Agent, error) {
 		return nil, fmt.Errorf("failed to create task_update tool: %w", err)
 	}
 
+	sshExecuteTool, err := tools.NewSSHExecuteTool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ssh_execute tool: %w", err)
+	}
+
 	agentConfig := llmagent.Config{
 		Name:        "executor",
 		Description: "Specialized agent for executing tasks using tools like image generation, email queries, email sending, web search, and web fetching",
@@ -156,6 +161,8 @@ func NewExecutorAgent(config *ExecutorAgentConfig) (agent.Agent, error) {
 			taskListTool,
 			taskGetTool,
 			taskUpdateTool,
+			// SSH 远程执行工具
+			sshExecuteTool,
 		},
 		Instruction: executorAgentInstruction,
 	}

--- a/internal/app/aiguide/router.go
+++ b/internal/app/aiguide/router.go
@@ -96,4 +96,13 @@ func registerSettingRoutes(db *gorm.DB, api *gin.RouterGroup) {
 		emailServerConfig.PUT("/:id", s.UpdateEmailServerConfig)
 		emailServerConfig.DELETE("/:id", s.DeleteEmailServerConfig)
 	}
+
+	sshServerConfig := api.Group("/ssh_server_configs")
+	{
+		sshServerConfig.POST("", s.CreateSSHServerConfig)
+		sshServerConfig.GET("", s.ListSSHServerConfigs)
+		sshServerConfig.GET("/:id", s.GetSSHServerConfig)
+		sshServerConfig.PUT("/:id", s.UpdateSSHServerConfig)
+		sshServerConfig.DELETE("/:id", s.DeleteSSHServerConfig)
+	}
 }

--- a/internal/app/aiguide/setting/ssh_server_config.go
+++ b/internal/app/aiguide/setting/ssh_server_config.go
@@ -1,0 +1,264 @@
+package setting
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"aiguide/internal/app/aiguide/table"
+	"aiguide/internal/pkg/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SSHServerConfigRequest is the request body for creating/updating an SSH server config.
+type SSHServerConfigRequest struct {
+	Name       string              `json:"name"        binding:"required"`
+	Host       string              `json:"host"        binding:"required"`
+	Port       int                 `json:"port"`
+	Username   string              `json:"username"    binding:"required"`
+	AuthMethod table.SSHAuthMethod `json:"auth_method"`
+	Password   string              `json:"password"`
+	PrivateKey string              `json:"private_key"`
+	Passphrase string              `json:"passphrase"`
+	IsDefault  bool                `json:"is_default"`
+}
+
+// SSHServerConfigResponse is the response body for SSH server config endpoints.
+// Private credentials are intentionally omitted from list responses; the full
+// private_key and passphrase are only returned by the single-item GET endpoint
+// so the edit form can pre-populate them.
+type SSHServerConfigResponse struct {
+	ID         int                 `json:"id"`
+	Name       string              `json:"name"`
+	Host       string              `json:"host"`
+	Port       int                 `json:"port"`
+	Username   string              `json:"username"`
+	AuthMethod table.SSHAuthMethod `json:"auth_method"`
+	Password   string              `json:"password,omitempty"`
+	PrivateKey string              `json:"private_key,omitempty"`
+	Passphrase string              `json:"passphrase,omitempty"`
+	IsDefault  bool                `json:"is_default"`
+	CreatedAt  time.Time           `json:"created_at"`
+	UpdatedAt  time.Time           `json:"updated_at"`
+}
+
+func toSSHResponse(cfg table.SSHServerConfig) SSHServerConfigResponse {
+	return SSHServerConfigResponse{
+		ID:         cfg.ID,
+		Name:       cfg.Name,
+		Host:       cfg.Host,
+		Port:       cfg.Port,
+		Username:   cfg.Username,
+		AuthMethod: cfg.AuthMethod,
+		Password:   cfg.Password,
+		PrivateKey: cfg.PrivateKey,
+		Passphrase: cfg.Passphrase,
+		IsDefault:  cfg.IsDefault,
+		CreatedAt:  cfg.CreatedAt,
+		UpdatedAt:  cfg.UpdatedAt,
+	}
+}
+
+// CreateSSHServerConfig creates a new SSH server config for the authenticated user.
+func (s *Setting) CreateSSHServerConfig(c *gin.Context) {
+	var req SSHServerConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		slog.Error("c.ShouldBindJSON() error", "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request: " + err.Error()})
+		return
+	}
+
+	userID, exists := middleware.GetUserID(c)
+	if !exists {
+		slog.Error("user not authenticated in CreateSSHServerConfig")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "user not authenticated"})
+		return
+	}
+
+	if req.Port == 0 {
+		req.Port = 22
+	}
+
+	authMethod := req.AuthMethod
+	if authMethod == "" {
+		authMethod = table.SSHAuthMethodPassword
+	}
+
+	cfg := table.SSHServerConfig{
+		UserID:     userID,
+		Name:       req.Name,
+		Host:       req.Host,
+		Port:       req.Port,
+		Username:   req.Username,
+		AuthMethod: authMethod,
+		Password:   req.Password, // SECURITY WARNING: stored in plain text
+		PrivateKey: req.PrivateKey,
+		Passphrase: req.Passphrase,
+		IsDefault:  req.IsDefault,
+	}
+
+	if err := s.db.Create(&cfg).Error; err != nil {
+		slog.Error("db.Create() error in CreateSSHServerConfig", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create config: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, toSSHResponse(cfg))
+}
+
+// ListSSHServerConfigs returns all SSH server configs for the authenticated user.
+func (s *Setting) ListSSHServerConfigs(c *gin.Context) {
+	userID, exists := middleware.GetUserID(c)
+	if !exists {
+		slog.Error("user not authenticated in ListSSHServerConfigs")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "user not authenticated"})
+		return
+	}
+
+	var configs []table.SSHServerConfig
+	if err := s.db.Where("user_id = ?", userID).Order("is_default DESC, created_at DESC").Find(&configs).Error; err != nil {
+		slog.Error("db.Find() error in ListSSHServerConfigs", "user_id", userID, "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list configs: " + err.Error()})
+		return
+	}
+
+	response := make([]SSHServerConfigResponse, 0, len(configs))
+	for _, cfg := range configs {
+		response = append(response, toSSHResponse(cfg))
+	}
+
+	c.JSON(http.StatusOK, gin.H{"configs": response})
+}
+
+// GetSSHServerConfig returns a single SSH server config by ID.
+func (s *Setting) GetSSHServerConfig(c *gin.Context) {
+	userID, exists := middleware.GetUserID(c)
+	if !exists {
+		slog.Error("user not authenticated in GetSSHServerConfig")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "user not authenticated"})
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		slog.Error("strconv.Atoi() error in GetSSHServerConfig", "id", c.Param("id"), "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+
+	var cfg table.SSHServerConfig
+	if err := s.db.Where("id = ? AND user_id = ?", id, userID).First(&cfg).Error; err != nil {
+		slog.Error("db.First() error in GetSSHServerConfig", "config_id", id, "user_id", userID, "err", err)
+		c.JSON(http.StatusNotFound, gin.H{"error": "config not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, toSSHResponse(cfg))
+}
+
+// UpdateSSHServerConfig updates an existing SSH server config.
+func (s *Setting) UpdateSSHServerConfig(c *gin.Context) {
+	var req SSHServerConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		slog.Error("c.ShouldBindJSON() error in UpdateSSHServerConfig", "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request: " + err.Error()})
+		return
+	}
+
+	userID, exists := middleware.GetUserID(c)
+	if !exists {
+		slog.Error("user not authenticated in UpdateSSHServerConfig")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "user not authenticated"})
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		slog.Error("strconv.Atoi() error in UpdateSSHServerConfig", "id", c.Param("id"), "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+
+	var cfg table.SSHServerConfig
+	if err := s.db.Where("id = ? AND user_id = ?", id, userID).First(&cfg).Error; err != nil {
+		slog.Error("db.First() error in UpdateSSHServerConfig", "config_id", id, "user_id", userID, "err", err)
+		c.JSON(http.StatusNotFound, gin.H{"error": "config not found"})
+		return
+	}
+
+	// If setting this one as default, clear other defaults for the user.
+	if req.IsDefault && !cfg.IsDefault {
+		if err := s.db.Model(&table.SSHServerConfig{}).
+			Where("user_id = ? AND id != ?", userID, id).
+			Update("is_default", false).Error; err != nil {
+			slog.Error("db.Update() error clearing is_default in UpdateSSHServerConfig", "user_id", userID, "id", id, "err", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update default config"})
+			return
+		}
+	}
+
+	if req.Port == 0 {
+		req.Port = 22
+	}
+
+	authMethod := req.AuthMethod
+	if authMethod == "" {
+		authMethod = table.SSHAuthMethodPassword
+	}
+
+	cfg.Name = req.Name
+	cfg.Host = req.Host
+	cfg.Port = req.Port
+	cfg.Username = req.Username
+	cfg.AuthMethod = authMethod
+	if req.Password != "" {
+		cfg.Password = req.Password // SECURITY WARNING: stored in plain text
+	}
+	if req.PrivateKey != "" {
+		cfg.PrivateKey = req.PrivateKey
+		cfg.Passphrase = req.Passphrase // update passphrase only when key changes
+	}
+	cfg.IsDefault = req.IsDefault
+
+	if err := s.db.Save(&cfg).Error; err != nil {
+		slog.Error("db.Save() error in UpdateSSHServerConfig", "config_id", cfg.ID, "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update config: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, toSSHResponse(cfg))
+}
+
+// DeleteSSHServerConfig deletes an SSH server config by ID.
+func (s *Setting) DeleteSSHServerConfig(c *gin.Context) {
+	userID, exists := middleware.GetUserID(c)
+	if !exists {
+		slog.Error("user not authenticated in DeleteSSHServerConfig")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "user not authenticated"})
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		slog.Error("strconv.Atoi() error in DeleteSSHServerConfig", "id", c.Param("id"), "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+
+	result := s.db.Where("id = ? AND user_id = ?", id, userID).Delete(&table.SSHServerConfig{})
+	if result.Error != nil {
+		slog.Error("db.Delete() error in DeleteSSHServerConfig", "id", id, "user_id", userID, "err", result.Error)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete config: " + result.Error.Error()})
+		return
+	}
+
+	if result.RowsAffected == 0 {
+		slog.Error("SSH server config not found for deletion", "id", id, "user_id", userID)
+		c.JSON(http.StatusNotFound, gin.H{"error": "config not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "deleted successfully"})
+}

--- a/internal/app/aiguide/table/table.go
+++ b/internal/app/aiguide/table/table.go
@@ -58,6 +58,30 @@ type EmailServerConfig struct {
 	IsDefault  bool   `gorm:"default:false"` // 是否为默认邮箱
 }
 
+// SSHAuthMethod distinguishes password-based from key-based SSH authentication.
+type SSHAuthMethod string
+
+const (
+	SSHAuthMethodPassword SSHAuthMethod = "password"
+	SSHAuthMethodKey      SSHAuthMethod = "key"
+)
+
+// SSHServerConfig SSH server configuration for a user
+type SSHServerConfig struct {
+	Model
+
+	UserID     int           `gorm:"not null;index"`                // Associated user ID
+	Name       string        `gorm:"not null"`                      // Display name to identify the server
+	Host       string        `gorm:"not null"`                      // Hostname or IP, e.g. 192.168.1.10
+	Port       int           `gorm:"not null;default:22"`           // SSH port, default 22
+	Username   string        `gorm:"not null"`                      // SSH login username
+	AuthMethod SSHAuthMethod `gorm:"not null;default:'password'"`   // "password" or "key"
+	Password   string        `gorm:"not null;default:''"`           // Used when AuthMethod == "password" (plain text; encrypt in production)
+	PrivateKey string        `gorm:"not null;default:'';type:text"` // PEM-encoded private key; used when AuthMethod == "key"
+	Passphrase string        `gorm:"not null;default:''"`           // Optional passphrase for encrypted private keys
+	IsDefault  bool          `gorm:"default:false"`                 // Whether this is the user's default SSH server
+}
+
 // UserMemory 用户记忆，用于跨会话记住用户特征
 type UserMemory struct {
 	Model
@@ -188,6 +212,7 @@ func GetAllModels() []any {
 		&SessionMeta{},
 		&Project{},
 		&EmailServerConfig{},
+		&SSHServerConfig{},
 		&UserMemory{},
 		&Task{},
 		&SharedConversation{},

--- a/internal/pkg/tools/ssh.go
+++ b/internal/pkg/tools/ssh.go
@@ -1,0 +1,284 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"aiguide/internal/app/aiguide/table"
+	"aiguide/internal/pkg/middleware"
+
+	gossh "golang.org/x/crypto/ssh"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+)
+
+const (
+	sshDialTimeout    = 15 * time.Second
+	sshCommandTimeout = 60 * time.Second
+	sshMaxOutputBytes = 1 << 20 // 1 MiB cap per stream
+)
+
+// SSHExecuteInput defines the input parameters for the ssh_execute tool.
+type SSHExecuteInput struct {
+	// ServerName is the Name field of the SSH server config to use.
+	// If empty and the user has a default server configured, that one is used.
+	ServerName string `json:"server_name,omitempty" jsonschema:"Name of the SSH server config to use. Leave empty to use the default server."`
+	// Command is the shell command to run on the remote machine.
+	Command string `json:"command" jsonschema:"Shell command to execute on the remote server."`
+}
+
+// SSHExecuteOutput holds the result of running a remote SSH command.
+type SSHExecuteOutput struct {
+	Success     bool   `json:"success"`
+	Stdout      string `json:"stdout,omitempty"`
+	Stderr      string `json:"stderr,omitempty"`
+	ExitCode    int    `json:"exit_code"`
+	Host        string `json:"host,omitempty"`
+	Error       string `json:"error,omitempty"`
+	NeedsConfig bool   `json:"needs_config,omitempty"`
+}
+
+// NewSSHExecuteTool creates a tool that executes shell commands on a remote
+// machine over SSH. Credentials are loaded from the user's stored SSH server
+// configs (set up via the /api/ssh_server_configs endpoints).
+// Both password and public-key authentication are supported.
+func NewSSHExecuteTool() (tool.Tool, error) {
+	cfg := functiontool.Config{
+		Name: "ssh_execute",
+		Description: "Execute a shell command on a remote machine via SSH. " +
+			"The user must have at least one SSH server configured at /api/ssh_server_configs. " +
+			"Specify server_name to target a particular server, or leave it empty to use the default. " +
+			"Returns stdout, stderr, and the exit code of the command.",
+	}
+
+	handler := func(ctx tool.Context, input SSHExecuteInput) (*SSHExecuteOutput, error) {
+		return executeSSHCommand(ctx, input)
+	}
+
+	return functiontool.New(cfg, handler)
+}
+
+// executeSSHCommand loads credentials from the DB and runs the requested command.
+func executeSSHCommand(ctx context.Context, input SSHExecuteInput) (*SSHExecuteOutput, error) {
+	select {
+	case <-ctx.Done():
+		return &SSHExecuteOutput{Success: false, Error: "operation cancelled"}, ctx.Err()
+	default:
+	}
+
+	if input.Command == "" {
+		return &SSHExecuteOutput{Success: false, Error: "command must not be empty"}, nil
+	}
+
+	tx, ok := middleware.GetTx(ctx)
+	if !ok {
+		slog.Error("middleware.GetTx() failed in executeSSHCommand")
+		return &SSHExecuteOutput{Success: false, Error: "internal error: database context unavailable"}, nil
+	}
+
+	userID, ok := middleware.GetUserID(ctx)
+	if !ok {
+		slog.Error("middleware.GetUserID() failed in executeSSHCommand")
+		return &SSHExecuteOutput{Success: false, Error: "internal error: user context unavailable"}, nil
+	}
+
+	// Resolve the SSH server config.
+	var serverCfg table.SSHServerConfig
+	if input.ServerName != "" {
+		if err := tx.Where("user_id = ? AND name = ?", userID, input.ServerName).
+			First(&serverCfg).Error; err != nil {
+			slog.Error("db.First() error in executeSSHCommand", "user_id", userID, "server_name", input.ServerName, "err", err)
+			return &SSHExecuteOutput{
+				Success:     false,
+				Error:       fmt.Sprintf("SSH server config %q not found. Please add it at /api/ssh_server_configs.", input.ServerName),
+				NeedsConfig: true,
+			}, nil
+		}
+	} else {
+		// Try the default server first; fall back to the most recently created one.
+		if err := tx.Where("user_id = ?", userID).
+			Order("is_default DESC, created_at DESC").
+			First(&serverCfg).Error; err != nil {
+			slog.Error("db.First() error finding default SSH config", "user_id", userID, "err", err)
+			return &SSHExecuteOutput{
+				Success:     false,
+				Error:       "No SSH server config found. Please add one at /api/ssh_server_configs.",
+				NeedsConfig: true,
+			}, nil
+		}
+	}
+
+	authMethods, err := buildAuthMethods(serverCfg)
+	if err != nil {
+		slog.Error("buildAuthMethods() error", "host", serverCfg.Host, "err", err)
+		return &SSHExecuteOutput{
+			Success: false,
+			Host:    fmt.Sprintf("%s:%d", serverCfg.Host, serverCfg.Port),
+			Error:   err.Error(),
+		}, nil
+	}
+
+	host := fmt.Sprintf("%s:%d", serverCfg.Host, serverCfg.Port)
+	slog.Info("ssh_execute: connecting", "host", host, "user", serverCfg.Username,
+		"auth_method", serverCfg.AuthMethod, "command", input.Command)
+
+	output, err := runSSHCommand(ctx, host, serverCfg.Username, authMethods, input.Command)
+	if err != nil {
+		slog.Error("runSSHCommand() error", "host", host, "err", err)
+		return &SSHExecuteOutput{
+			Success: false,
+			Host:    host,
+			Error:   err.Error(),
+		}, nil
+	}
+
+	return output, nil
+}
+
+// buildAuthMethods converts a stored SSHServerConfig into the slice of
+// gossh.AuthMethod values that the SSH client will try in order.
+func buildAuthMethods(cfg table.SSHServerConfig) ([]gossh.AuthMethod, error) {
+	// Treat an empty AuthMethod as "password" for backwards compatibility.
+	method := cfg.AuthMethod
+	if method == "" {
+		method = table.SSHAuthMethodPassword
+	}
+
+	switch method {
+	case table.SSHAuthMethodPassword:
+		return []gossh.AuthMethod{gossh.Password(cfg.Password)}, nil
+
+	case table.SSHAuthMethodKey:
+		if cfg.PrivateKey == "" {
+			return nil, fmt.Errorf("auth_method is %q but no private key is stored", method)
+		}
+		signer, err := parsePrivateKey([]byte(cfg.PrivateKey), []byte(cfg.Passphrase))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse private key: %w", err)
+		}
+		return []gossh.AuthMethod{gossh.PublicKeys(signer)}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown auth_method %q; expected %q or %q",
+			method, table.SSHAuthMethodPassword, table.SSHAuthMethodKey)
+	}
+}
+
+// parsePrivateKey parses a PEM-encoded private key, decrypting it with
+// passphrase if it is non-empty.
+func parsePrivateKey(pemBytes, passphrase []byte) (gossh.Signer, error) {
+	if len(passphrase) > 0 {
+		return gossh.ParsePrivateKeyWithPassphrase(pemBytes, passphrase)
+	}
+	return gossh.ParsePrivateKey(pemBytes)
+}
+
+// runSSHCommand dials the SSH server, runs cmd, and returns the captured output.
+// A non-zero exit code is reflected in output.ExitCode but is NOT treated as an
+// error at the Go level — the caller decides what to do with it.
+func runSSHCommand(ctx context.Context, host, username string, authMethods []gossh.AuthMethod, cmd string) (*SSHExecuteOutput, error) {
+	sshCfg := &gossh.ClientConfig{
+		User: username,
+		Auth: authMethods,
+		// InsecureIgnoreHostKey is acceptable for an AI-assistant use-case where
+		// the user is deliberately connecting to a host they control.
+		// For production hardening, replace with a known-hosts verifier.
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(), //nolint:gosec
+		Timeout:         sshDialTimeout,
+	}
+
+	// Respect context cancellation during dial.
+	dialDone := make(chan struct {
+		client *gossh.Client
+		err    error
+	}, 1)
+	go func() {
+		client, err := gossh.Dial("tcp", host, sshCfg)
+		dialDone <- struct {
+			client *gossh.Client
+			err    error
+		}{client, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("context cancelled while dialling SSH host %s", host)
+	case result := <-dialDone:
+		if result.err != nil {
+			return nil, fmt.Errorf("SSH dial error for host %s: %w", host, result.err)
+		}
+		defer result.client.Close()
+		return runOnClient(ctx, result.client, host, cmd)
+	}
+}
+
+// runOnClient opens a session on an already-established SSH client and runs cmd.
+func runOnClient(ctx context.Context, client *gossh.Client, host, cmd string) (*SSHExecuteOutput, error) {
+	session, err := client.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open SSH session on %s: %w", host, err)
+	}
+	defer session.Close()
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	session.Stdout = &limitedWriter{buf: &stdoutBuf, limit: sshMaxOutputBytes}
+	session.Stderr = &limitedWriter{buf: &stderrBuf, limit: sshMaxOutputBytes}
+
+	// Run with a timeout derived from the context or our hard cap.
+	cmdCtx, cancel := context.WithTimeout(ctx, sshCommandTimeout)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- session.Run(cmd)
+	}()
+
+	var runErr error
+	select {
+	case <-cmdCtx.Done():
+		_ = session.Signal(gossh.SIGKILL)
+		return nil, fmt.Errorf("SSH command timed out on %s", host)
+	case runErr = <-done:
+	}
+
+	exitCode := 0
+	if runErr != nil {
+		if exitErr, ok := runErr.(*gossh.ExitError); ok {
+			exitCode = exitErr.ExitStatus()
+			runErr = nil // non-zero exit is not a Go-level error
+		} else {
+			return nil, fmt.Errorf("SSH run error on %s: %w", host, runErr)
+		}
+	}
+
+	return &SSHExecuteOutput{
+		Success:  exitCode == 0,
+		Stdout:   stdoutBuf.String(),
+		Stderr:   stderrBuf.String(),
+		ExitCode: exitCode,
+		Host:     host,
+	}, nil
+}
+
+// limitedWriter caps writes to a bytes.Buffer at a maximum byte count.
+type limitedWriter struct {
+	buf     *bytes.Buffer
+	limit   int
+	written int
+}
+
+func (w *limitedWriter) Write(p []byte) (int, error) {
+	remaining := w.limit - w.written
+	if remaining <= 0 {
+		return len(p), nil // silently discard overflow
+	}
+	if len(p) > remaining {
+		p = p[:remaining]
+	}
+	n, err := w.buf.Write(p)
+	w.written += n
+	return n, err
+}

--- a/internal/pkg/tools/ssh_test.go
+++ b/internal/pkg/tools/ssh_test.go
@@ -1,0 +1,486 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+
+	"aiguide/internal/app/aiguide/table"
+
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// TestNewSSHExecuteTool verifies the constructor returns a non-nil tool.
+func TestNewSSHExecuteTool(t *testing.T) {
+	tool, err := NewSSHExecuteTool()
+	if err != nil {
+		t.Fatalf("NewSSHExecuteTool() error = %v", err)
+	}
+	if tool == nil {
+		t.Fatal("NewSSHExecuteTool() returned nil")
+	}
+}
+
+// TestSSHExecute_EmptyCommand verifies that an empty command returns Success=false.
+func TestSSHExecute_EmptyCommand(t *testing.T) {
+	output, err := executeSSHCommand(context.Background(), SSHExecuteInput{Command: ""})
+	if err != nil {
+		t.Fatalf("executeSSHCommand() unexpected Go error: %v", err)
+	}
+	if output.Success {
+		t.Error("expected Success=false for empty command")
+	}
+	if output.Error == "" {
+		t.Error("expected non-empty Error for empty command")
+	}
+}
+
+// TestSSHExecute_MissingDBContext verifies graceful failure when no DB is in context.
+func TestSSHExecute_MissingDBContext(t *testing.T) {
+	output, err := executeSSHCommand(context.Background(), SSHExecuteInput{Command: "echo hi"})
+	if err != nil {
+		t.Fatalf("executeSSHCommand() unexpected Go error: %v", err)
+	}
+	if output.Success {
+		t.Error("expected Success=false when DB context is missing")
+	}
+	if !strings.Contains(output.Error, "database context") {
+		t.Errorf("unexpected error message: %q", output.Error)
+	}
+}
+
+// TestSSHExecute_CancelledContext verifies the context cancellation path.
+func TestSSHExecute_CancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	output, err := executeSSHCommand(ctx, SSHExecuteInput{Command: "echo hi"})
+	// Either a structured output or a context error is acceptable.
+	if err == nil && output != nil && output.Success {
+		t.Error("expected failure for already-cancelled context")
+	}
+}
+
+// TestLimitedWriter_CapsBytesWritten verifies that limitedWriter stops at limit.
+func TestLimitedWriter_CapsBytesWritten(t *testing.T) {
+	var buf bytes.Buffer
+	lw := &limitedWriter{buf: &buf, limit: 10}
+
+	n, err := lw.Write([]byte("hello world! this is way more than ten bytes"))
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	// n should equal len(input) — limitedWriter silently discards the excess.
+	if n == 0 {
+		t.Fatal("Write() returned 0 bytes written")
+	}
+	if buf.Len() > 10 {
+		t.Errorf("buffer exceeds limit: got %d bytes, want <= 10", buf.Len())
+	}
+}
+
+// TestLimitedWriter_MultipleWrites verifies accumulation across writes.
+func TestLimitedWriter_MultipleWrites(t *testing.T) {
+	var buf bytes.Buffer
+	lw := &limitedWriter{buf: &buf, limit: 5}
+
+	lw.Write([]byte("abc")) //nolint:errcheck
+	lw.Write([]byte("def")) //nolint:errcheck
+
+	if buf.Len() > 5 {
+		t.Errorf("buffer exceeds limit after two writes: got %d bytes", buf.Len())
+	}
+	if !strings.HasPrefix(buf.String(), "abcde") {
+		t.Errorf("unexpected buffer content: %q", buf.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// In-process mock SSH server helpers
+// ---------------------------------------------------------------------------
+
+// startMockSSHServer starts a minimal in-process SSH server that accepts
+// password authentication and executes the requested command via a simple
+// built-in dispatcher (no real shell). It returns the listener address and a
+// stop function.
+func startMockSSHServer(t *testing.T, username, password string, handler func(cmd string) (stdout, stderr string, exitCode int)) (addr string, stop func()) {
+	t.Helper()
+
+	// Generate host key.
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey() error = %v", err)
+	}
+	hostSigner, err := gossh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatalf("gossh.NewSignerFromKey() error = %v", err)
+	}
+
+	config := &gossh.ServerConfig{
+		PasswordCallback: func(conn gossh.ConnMetadata, pass []byte) (*gossh.Permissions, error) {
+			if conn.User() == username && string(pass) == password {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("invalid credentials")
+		},
+	}
+	config.AddHostKey(hostSigner)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() error = %v", err)
+	}
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			go handleMockSSHConn(conn, config, handler)
+		}
+	}()
+
+	return ln.Addr().String(), func() { ln.Close() }
+}
+
+// startMockSSHServerWithKey starts a minimal in-process SSH server that only
+// accepts public-key authentication for the given authorisedKey. It returns the
+// listener address and a stop function.
+func startMockSSHServerWithKey(t *testing.T, username string, authorisedKey gossh.PublicKey, handler func(cmd string) (stdout, stderr string, exitCode int)) (addr string, stop func()) {
+	t.Helper()
+
+	hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey() for host key: %v", err)
+	}
+	hostSigner, err := gossh.NewSignerFromKey(hostKey)
+	if err != nil {
+		t.Fatalf("gossh.NewSignerFromKey() for host key: %v", err)
+	}
+
+	authorisedKeyBytes := authorisedKey.Marshal()
+
+	config := &gossh.ServerConfig{
+		PublicKeyCallback: func(conn gossh.ConnMetadata, key gossh.PublicKey) (*gossh.Permissions, error) {
+			if conn.User() == username && bytes.Equal(key.Marshal(), authorisedKeyBytes) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("unauthorised key")
+		},
+	}
+	config.AddHostKey(hostSigner)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() error = %v", err)
+	}
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go handleMockSSHConn(conn, config, handler)
+		}
+	}()
+
+	return ln.Addr().String(), func() { ln.Close() }
+}
+
+func handleMockSSHConn(conn net.Conn, config *gossh.ServerConfig, handler func(cmd string) (string, string, int)) {
+	sshConn, chans, reqs, err := gossh.NewServerConn(conn, config)
+	if err != nil {
+		return
+	}
+	defer sshConn.Close()
+
+	go gossh.DiscardRequests(reqs)
+
+	for newChan := range chans {
+		if newChan.ChannelType() != "session" {
+			newChan.Reject(gossh.UnknownChannelType, "unsupported channel type") //nolint:errcheck
+			continue
+		}
+		ch, requests, err := newChan.Accept()
+		if err != nil {
+			continue
+		}
+		go func(ch gossh.Channel, requests <-chan *gossh.Request) {
+			defer ch.Close()
+			for req := range requests {
+				if req.Type != "exec" {
+					if req.WantReply {
+						req.Reply(false, nil) //nolint:errcheck
+					}
+					continue
+				}
+				// Parse the command length-prefixed payload.
+				if len(req.Payload) < 4 {
+					if req.WantReply {
+						req.Reply(false, nil) //nolint:errcheck
+					}
+					continue
+				}
+				cmdLen := int(req.Payload[0])<<24 | int(req.Payload[1])<<16 | int(req.Payload[2])<<8 | int(req.Payload[3])
+				if len(req.Payload) < 4+cmdLen {
+					if req.WantReply {
+						req.Reply(false, nil) //nolint:errcheck
+					}
+					continue
+				}
+				cmd := string(req.Payload[4 : 4+cmdLen])
+				if req.WantReply {
+					req.Reply(true, nil) //nolint:errcheck
+				}
+
+				stdout, stderr, exitCode := handler(cmd)
+				io.WriteString(ch, stdout)          //nolint:errcheck
+				io.WriteString(ch.Stderr(), stderr) //nolint:errcheck
+
+				exitPayload := gossh.Marshal(struct{ Status uint32 }{uint32(exitCode)})
+				ch.SendRequest("exit-status", false, exitPayload) //nolint:errcheck
+				return
+			}
+		}(ch, requests)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests using the mock SSH server — password auth
+// ---------------------------------------------------------------------------
+
+// TestRunSSHCommand_Success verifies stdout capture and exit code 0.
+func TestRunSSHCommand_Success(t *testing.T) {
+	addr, stop := startMockSSHServer(t, "user", "pass", func(cmd string) (string, string, int) {
+		return "hello\n", "", 0
+	})
+	defer stop()
+
+	authMethods := []gossh.AuthMethod{gossh.Password("pass")}
+	output, err := runSSHCommand(context.Background(), addr, "user", authMethods, "echo hello")
+	if err != nil {
+		t.Fatalf("runSSHCommand() error = %v", err)
+	}
+	if !output.Success {
+		t.Errorf("expected Success=true, got error: %s", output.Error)
+	}
+	if output.ExitCode != 0 {
+		t.Errorf("expected ExitCode=0, got %d", output.ExitCode)
+	}
+	if !strings.Contains(output.Stdout, "hello") {
+		t.Errorf("expected stdout to contain 'hello', got: %q", output.Stdout)
+	}
+}
+
+// TestRunSSHCommand_NonZeroExit verifies that a non-zero exit is reflected in
+// ExitCode and Success=false, but not returned as a Go error.
+func TestRunSSHCommand_NonZeroExit(t *testing.T) {
+	addr, stop := startMockSSHServer(t, "user", "pass", func(cmd string) (string, string, int) {
+		return "", "command not found\n", 127
+	})
+	defer stop()
+
+	authMethods := []gossh.AuthMethod{gossh.Password("pass")}
+	output, err := runSSHCommand(context.Background(), addr, "user", authMethods, "nonexistent")
+	if err != nil {
+		t.Fatalf("runSSHCommand() unexpected Go error for non-zero exit: %v", err)
+	}
+	if output.Success {
+		t.Error("expected Success=false for exit code 127")
+	}
+	if output.ExitCode != 127 {
+		t.Errorf("expected ExitCode=127, got %d", output.ExitCode)
+	}
+	if !strings.Contains(output.Stderr, "command not found") {
+		t.Errorf("expected stderr to contain 'command not found', got: %q", output.Stderr)
+	}
+}
+
+// TestRunSSHCommand_WrongPassword verifies that invalid credentials return an error.
+func TestRunSSHCommand_WrongPassword(t *testing.T) {
+	addr, stop := startMockSSHServer(t, "user", "correctpass", func(cmd string) (string, string, int) {
+		return "ok", "", 0
+	})
+	defer stop()
+
+	authMethods := []gossh.AuthMethod{gossh.Password("wrongpass")}
+	_, err := runSSHCommand(context.Background(), addr, "user", authMethods, "echo hi")
+	if err == nil {
+		t.Fatal("expected error for wrong password, got nil")
+	}
+}
+
+// TestRunSSHCommand_StderrCapture verifies stderr is captured separately.
+func TestRunSSHCommand_StderrCapture(t *testing.T) {
+	addr, stop := startMockSSHServer(t, "user", "pass", func(cmd string) (string, string, int) {
+		return "out\n", "err\n", 0
+	})
+	defer stop()
+
+	authMethods := []gossh.AuthMethod{gossh.Password("pass")}
+	output, err := runSSHCommand(context.Background(), addr, "user", authMethods, "cmd")
+	if err != nil {
+		t.Fatalf("runSSHCommand() error = %v", err)
+	}
+	if !strings.Contains(output.Stdout, "out") {
+		t.Errorf("expected stdout 'out', got %q", output.Stdout)
+	}
+	if !strings.Contains(output.Stderr, "err") {
+		t.Errorf("expected stderr 'err', got %q", output.Stderr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests using the mock SSH server — public-key auth
+// ---------------------------------------------------------------------------
+
+// generateRSAKeyPairForTest generates an RSA key pair and returns the private
+// key as a PEM-encoded byte slice plus the corresponding gossh.PublicKey.
+func generateRSAKeyPairForTest(t *testing.T) (privatePEM []byte, pub gossh.PublicKey) {
+	t.Helper()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey(): %v", err)
+	}
+	der := x509.MarshalPKCS1PrivateKey(privateKey)
+	privatePEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der})
+
+	signer, err := gossh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatalf("gossh.NewSignerFromKey(): %v", err)
+	}
+	return privatePEM, signer.PublicKey()
+}
+
+// TestRunSSHCommand_PublicKeyAuth verifies end-to-end public-key authentication
+// against a mock SSH server that only accepts public-key auth.
+func TestRunSSHCommand_PublicKeyAuth(t *testing.T) {
+	privatePEM, pubKey := generateRSAKeyPairForTest(t)
+
+	addr, stop := startMockSSHServerWithKey(t, "user", pubKey, func(cmd string) (string, string, int) {
+		return "key-auth-ok\n", "", 0
+	})
+	defer stop()
+
+	signer, err := gossh.ParsePrivateKey(privatePEM)
+	if err != nil {
+		t.Fatalf("gossh.ParsePrivateKey(): %v", err)
+	}
+	authMethods := []gossh.AuthMethod{gossh.PublicKeys(signer)}
+
+	output, err := runSSHCommand(context.Background(), addr, "user", authMethods, "echo key-auth-ok")
+	if err != nil {
+		t.Fatalf("runSSHCommand() error = %v", err)
+	}
+	if !output.Success {
+		t.Errorf("expected Success=true, got error: %s", output.Error)
+	}
+	if !strings.Contains(output.Stdout, "key-auth-ok") {
+		t.Errorf("expected stdout to contain 'key-auth-ok', got: %q", output.Stdout)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for buildAuthMethods
+// ---------------------------------------------------------------------------
+
+// newTestSSHConfig builds a minimal SSHServerConfig for buildAuthMethods tests.
+func newTestSSHConfig(authMethod table.SSHAuthMethod, password, privateKey, passphrase string) table.SSHServerConfig {
+	return table.SSHServerConfig{
+		AuthMethod: authMethod,
+		Password:   password,
+		PrivateKey: privateKey,
+		Passphrase: passphrase,
+	}
+}
+
+// TestBuildAuthMethods_Password verifies that a password config returns exactly
+// one auth method without error.
+func TestBuildAuthMethods_Password(t *testing.T) {
+	cfg := newTestSSHConfig(table.SSHAuthMethodPassword, "secret", "", "")
+	methods, err := buildAuthMethods(cfg)
+	if err != nil {
+		t.Fatalf("buildAuthMethods() error = %v", err)
+	}
+	if len(methods) != 1 {
+		t.Fatalf("expected 1 auth method, got %d", len(methods))
+	}
+}
+
+// TestBuildAuthMethods_EmptyMethodDefaultsToPassword verifies that an empty
+// AuthMethod field is treated as "password" for backwards compatibility.
+func TestBuildAuthMethods_EmptyMethodDefaultsToPassword(t *testing.T) {
+	cfg := newTestSSHConfig("", "secret", "", "")
+	methods, err := buildAuthMethods(cfg)
+	if err != nil {
+		t.Fatalf("buildAuthMethods() error = %v", err)
+	}
+	if len(methods) != 1 {
+		t.Fatalf("expected 1 auth method, got %d", len(methods))
+	}
+}
+
+// TestBuildAuthMethods_KeyMissingKey verifies that key auth with no private key
+// stored returns an error.
+func TestBuildAuthMethods_KeyMissingKey(t *testing.T) {
+	cfg := newTestSSHConfig(table.SSHAuthMethodKey, "", "", "")
+	_, err := buildAuthMethods(cfg)
+	if err == nil {
+		t.Fatal("expected error for key auth with empty private key")
+	}
+}
+
+// TestBuildAuthMethods_KeyValid verifies that a valid PEM private key produces
+// one auth method without error.
+func TestBuildAuthMethods_KeyValid(t *testing.T) {
+	privatePEM, _ := generateRSAKeyPairForTest(t)
+	cfg := newTestSSHConfig(table.SSHAuthMethodKey, "", string(privatePEM), "")
+	methods, err := buildAuthMethods(cfg)
+	if err != nil {
+		t.Fatalf("buildAuthMethods() error = %v", err)
+	}
+	if len(methods) != 1 {
+		t.Fatalf("expected 1 auth method, got %d", len(methods))
+	}
+}
+
+// TestBuildAuthMethods_UnknownMethod verifies that an unknown auth method
+// returns an error.
+func TestBuildAuthMethods_UnknownMethod(t *testing.T) {
+	cfg := newTestSSHConfig("agent", "", "", "")
+	_, err := buildAuthMethods(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown auth method")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for parsePrivateKey
+// ---------------------------------------------------------------------------
+
+// TestParsePrivateKey_Valid verifies parsing a valid unencrypted PEM key.
+func TestParsePrivateKey_Valid(t *testing.T) {
+	privatePEM, _ := generateRSAKeyPairForTest(t)
+	_, err := parsePrivateKey(privatePEM, nil)
+	if err != nil {
+		t.Fatalf("parsePrivateKey() error = %v", err)
+	}
+}
+
+// TestParsePrivateKey_Invalid verifies that garbage input returns an error.
+func TestParsePrivateKey_Invalid(t *testing.T) {
+	_, err := parsePrivateKey([]byte("not-a-pem-key"), nil)
+	if err == nil {
+		t.Fatal("expected error for invalid PEM, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `SSHServerConfig` DB table with `auth_method` (`password` | `key`), `private_key` (PEM text), and `passphrase` fields; registered in `GetAllModels()` for auto-migration
- Implement `ssh_execute` agent tool (`internal/pkg/tools/ssh.go`) with `buildAuthMethods` dispatching on auth type and `parsePrivateKey` for encrypted key support; tool registered in executor agent
- Add full CRUD REST API under `/api/ssh_server_configs` (`internal/app/aiguide/setting/ssh_server_config.go`) following the email-server-config pattern
- Add SSH Servers entry to `SessionSidebar` user dropdown
- Add settings UI (`frontend/app/settings/ssh-servers/page.tsx`) with Password / Public key toggle, conditional password or PEM textarea + passphrase fields
- Add comprehensive tests including mock in-process SSH server integration tests for password and public-key auth paths, `buildAuthMethods` unit tests, and `parsePrivateKey` unit tests