### PR TITLE
fix(frontend): prevent first message from disappearing on new session

### DIFF
--- a/frontend/app/chat/ChatPageClient.tsx
+++ b/frontend/app/chat/ChatPageClient.tsx
@@ -60,6 +60,7 @@ export default function ChatPageClient() {
     handleRenameProject,
     handleAssignSessionProject,
     shouldLoadOlderMessages,
+    markSessionLoaded,
   } = useSessionData({
     agentId,
     userId: user?.user_id,
@@ -83,6 +84,7 @@ export default function ChatPageClient() {
     loadSessions,
     setMessages,
     setInputValue: (v) => setInputValueRef.current(v),
+    markSessionLoaded,
   });
 
   const isStreamingResponse = useMemo(

--- a/frontend/app/chat/[sessionId]/hooks/useSessionData.ts
+++ b/frontend/app/chat/[sessionId]/hooks/useSessionData.ts
@@ -87,5 +87,6 @@ export function useSessionData({
     handleRenameProject: projectState.handleRenameProject,
     handleAssignSessionProject: projectState.handleAssignSessionProject,
     shouldLoadOlderMessages: historyState.shouldLoadOlderMessages,
+    markSessionLoaded: historyState.markSessionLoaded,
   };
 }

--- a/frontend/app/chat/[sessionId]/hooks/useSessionHistory.ts
+++ b/frontend/app/chat/[sessionId]/hooks/useSessionHistory.ts
@@ -185,6 +185,10 @@ export function useSessionHistory({
     return scrollTop < LOAD_MORE_THRESHOLD && hasMoreMessages && !isLoadingOlderMessages && !isLoadingHistory;
   }, [hasMoreMessages, isLoadingHistory, isLoadingOlderMessages]);
 
+  const markSessionLoaded = useCallback((id: string) => {
+    autoLoadedSessionIdRef.current = id;
+  }, []);
+
   return {
     messages,
     setMessages,
@@ -197,5 +201,6 @@ export function useSessionHistory({
     loadSessionHistory,
     loadOlderMessages,
     shouldLoadOlderMessages,
+    markSessionLoaded,
   };
 }

--- a/frontend/app/chat/[sessionId]/hooks/useStreamingChat.ts
+++ b/frontend/app/chat/[sessionId]/hooks/useStreamingChat.ts
@@ -22,6 +22,7 @@ interface UseStreamingChatParams {
   loadSessions: (silent?: boolean) => Promise<Session[] | undefined>;
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
   setInputValue: React.Dispatch<React.SetStateAction<string>>;
+  markSessionLoaded: (id: string) => void;
 }
 
 export function useStreamingChat({
@@ -37,6 +38,7 @@ export function useStreamingChat({
   loadSessions,
   setMessages,
   setInputValue,
+  markSessionLoaded,
 }: UseStreamingChatParams) {
   const [isLoading, setIsLoading] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -72,6 +74,7 @@ export function useStreamingChat({
     const resolvedSessionId = resolveSessionId(targetSessionId, activeSessionIdRef.current);
     const isDraftSession = !activeSessionIdRef.current;
     if (resolvedSessionId !== activeSessionIdRef.current || isDraftSession) {
+      markSessionLoaded(resolvedSessionId);
       window.history.pushState(null, '', getChatPath(resolvedSessionId));
       activeSessionIdRef.current = resolvedSessionId;
       setSessionId(resolvedSessionId);
@@ -200,7 +203,7 @@ export function useStreamingChat({
       setIsLoading(false);
       abortControllerRef.current = null;
     }
-  }, [agentId, authenticatedFetch, clearImages, clearTitlePoll, currentProjectId, isLoading, loadSessions, messages, sessionId, sessions, setInputValue, setMessages, setSessionId, userId]);
+  }, [agentId, authenticatedFetch, clearImages, clearTitlePoll, currentProjectId, isLoading, loadSessions, markSessionLoaded, messages, sessionId, sessions, setInputValue, setMessages, setSessionId, userId]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary

- First message sometimes disappears when starting a new chat session
- Root cause: `window.history.pushState` in `sendMessage` causes Next.js App Router to update `useParams()`, which triggers `useSessionHistory`'s effect to call `loadSessionHistory` → `resetSessionView` → `setMessages([])`, wiping the just-added user message
- Fix: expose `markSessionLoaded(id)` from `useSessionHistory` and call it before `pushState` so the effect's guard (`autoLoadedSessionIdRef === sessionId`) short-circuits the spurious history reload

## Test plan

- [ ] Start a new chat (navigate to `/chat`)
- [ ] Send a first message — verify the user message stays visible while waiting for the response
- [ ] Repeat several times to confirm the intermittent disappearance is gone
- [ ] Verify switching between existing sessions still loads history correctly