### PR TITLE
test(frontend): add markSessionLoaded to useStreamingChat test mock

### DIFF
--- a/frontend/app/chat/[sessionId]/hooks/useStreamingChat.test.tsx
+++ b/frontend/app/chat/[sessionId]/hooks/useStreamingChat.test.tsx
@@ -45,6 +45,7 @@ describe('useStreamingChat', () => {
       loadSessions,
       setMessages,
       setInputValue,
+      markSessionLoaded: vi.fn(),
     }));
 
     expect(pushStateSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Follow-up to #255: the `useStreamingChat` hook now requires a `markSessionLoaded` prop, but the existing test was missing it, causing `pnpm verify` to fail with `markSessionLoaded is not a function`
- Adds `markSessionLoaded: vi.fn()` to the test's hook params

## Test plan

- [ ] `cd frontend && pnpm verify` passes (lint + tests + build)