### PR TITLE
fix(frontend): allow unauthenticated access to shared conversation pages

### DIFF
--- a/frontend/app/contexts/AuthContext.tsx
+++ b/frontend/app/contexts/AuthContext.tsx
@@ -29,7 +29,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const handleUnauthorized = useCallback(() => {
     setUser(null);
-    if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
+    if (
+      typeof window !== 'undefined' &&
+      window.location.pathname !== '/login' &&
+      !window.location.pathname.startsWith('/share/')
+    ) {
       router.push('/login');
     }
   }, [router]);


### PR DESCRIPTION
## Summary

- The `AuthContext` `handleUnauthorized` callback was unconditionally redirecting unauthenticated visitors to `/login`, including those visiting public `/share/:shareId` pages.
- Added a path guard to skip the redirect when `window.location.pathname` starts with `/share/`.
- The backend `GET /api/share/:shareId` endpoint was already public (registered before the auth middleware in `router.go`); no backend changes were needed.

## Changes

- `frontend/app/contexts/AuthContext.tsx`: added `!window.location.pathname.startsWith('/share/')` condition to `handleUnauthorized`.