### PR TITLE
fix(assistant): remove extra newline prefix when copying first message

### DIFF
--- a/internal/app/aiguide/assistant/sse.go
+++ b/internal/app/aiguide/assistant/sse.go
@@ -551,7 +551,7 @@ func (a *Assistant) fetchUserMemories(userID int) (string, error) {
 func prependMemoryContext(parts []*genai.Part, memoryContext string) []*genai.Part {
 	for i, part := range parts {
 		if part.Text != "" {
-			parts[i] = genai.NewPartFromText(memoryContext + "\n" + part.Text)
+			parts[i] = genai.NewPartFromText(memoryContext + part.Text)
 			return parts
 		}
 	}


### PR DESCRIPTION
## Summary

- `prependMemoryContext` joined the memory context (which already ends with `\n`) and the user message with an extra `"\n"`, storing a double newline in the ADK session
- When session history is loaded, `stripUserContext` removes `<user_context>...</user_context>\n` exactly but leaves the extra `\n` behind
- This caused a spurious leading newline when copying the first user message — only affected sessions where user memories exist

## Test plan

- [ ] Create a session with user memories present
- [ ] Send a first message
- [ ] Copy the user message — confirm no leading newline in clipboard