### PR TITLE
feat(frontend): add voice input with mic button and ripple animation

### DIFF
--- a/frontend/app/chat/ChatPageClient.tsx
+++ b/frontend/app/chat/ChatPageClient.tsx
@@ -12,6 +12,7 @@ import { useScrollManager } from './[sessionId]/hooks/useScrollManager';
 import { useSessionData } from './[sessionId]/hooks/useSessionData';
 import { useStreamingChat } from './[sessionId]/hooks/useStreamingChat';
 import { useUIState } from './[sessionId]/hooks/useUIState';
+import { useVoiceInput } from './[sessionId]/hooks/useVoiceInput';
 import { mergeAssistantMessages } from './[sessionId]/utils/messages';
 
 export default function ChatPageClient() {
@@ -119,6 +120,13 @@ export default function ChatPageClient() {
     };
     setInputValueRef.current = setInputValue;
   }, [setEditingMessageId, setEditingValue, setInputValue]);
+
+  const { isRecording, isSupported: isVoiceSupported, toggleRecording, voiceError } = useVoiceInput({
+    onTranscript: useCallback((text: string) => {
+      actions.setInputValue((prev) => (prev ? `${prev} ${text}` : text));
+    }, [actions]),
+    disabled: isLoading,
+  });
 
   const scroll = useScrollManager({
     messages,
@@ -319,6 +327,10 @@ export default function ChatPageClient() {
       onRemoveImage={handleRemoveImage}
       onImageSelect={handleImageSelect}
       onClearQuote={actions.handleClearQuote}
+      isRecording={isRecording}
+      isVoiceSupported={isVoiceSupported}
+      onVoiceToggle={toggleRecording}
+      voiceError={voiceError}
       onCloseShareModal={ui.handleCloseShareModal}
       onCloseCreateProjectModal={ui.handleCloseCreateProjectModal}
       onSubmitCreateProject={handleCreateProject}

--- a/frontend/app/chat/[sessionId]/components/ChatInput.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatInput.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, memo, useRef } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { Textarea } from '@/app/components/ui/textarea';
-import { ArrowUp, X, Paperclip, MessageSquare, FileText, AudioLines } from 'lucide-react';
+import { ArrowUp, X, Paperclip, MessageSquare, FileText, AudioLines, Mic } from 'lucide-react';
 import { cn } from '@/app/lib/utils';
 import type { SelectedImage } from '../types';
 
@@ -25,6 +25,10 @@ interface ChatInputProps {
   agentName: string;
   quotedText?: string;
   onClearQuote?: () => void;
+  isRecording?: boolean;
+  isVoiceSupported?: boolean;
+  onVoiceToggle?: () => void;
+  voiceError?: string | null;
 }
 
 const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(({ 
@@ -47,6 +51,10 @@ const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(({
   agentName,
   quotedText,
   onClearQuote,
+  isRecording = false,
+  isVoiceSupported = false,
+  onVoiceToggle,
+  voiceError,
 }, textareaRef) => {
   const imageInputRef = useRef<HTMLInputElement>(null);
 
@@ -108,6 +116,11 @@ const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(({
               {imageError}
             </div>
           )}
+          {voiceError && (
+            <div className="px-3 pt-2 text-xs text-red-500" role="alert" aria-live="polite">
+              {voiceError}
+            </div>
+          )}
           <form onSubmit={onSubmit} className="w-full flex items-center p-2 gap-2">
             <input
               ref={imageInputRef}
@@ -129,6 +142,34 @@ const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(({
               >
                 <Paperclip className="h-4 w-4 sm:h-3.5 sm:w-3.5" />
               </Button>
+            {isVoiceSupported && (
+              <div className="relative flex items-center justify-center flex-shrink-0">
+                {isRecording && (
+                  <span
+                    className="absolute inset-0 rounded-full bg-red-500 animate-mic-ripple"
+                    aria-hidden="true"
+                  />
+                )}
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  onClick={onVoiceToggle}
+                  disabled={isLoading || isLoadingHistory}
+                  className={cn(
+                    "relative h-8 w-8 sm:h-7 sm:w-7 rounded-full transition-all duration-200",
+                    isRecording
+                      ? "bg-red-500 text-white hover:bg-red-600 shadow-md"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                  title={isRecording ? "停止录音" : "语音输入"}
+                  aria-label={isRecording ? "停止录音" : "语音输入"}
+                  aria-pressed={isRecording}
+                >
+                  <Mic className="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+                </Button>
+              </div>
+            )}
             <Textarea
               ref={textareaRef}
               value={inputValue}

--- a/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
@@ -95,6 +95,12 @@ interface ChatPageLayoutProps {
   onImageSelect: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onClearQuote: () => void;
 
+  // Voice input
+  isRecording?: boolean;
+  isVoiceSupported?: boolean;
+  onVoiceToggle?: () => void;
+  voiceError?: string | null;
+
   // Handlers – modals
   onCloseShareModal: () => void;
   onCloseCreateProjectModal: () => void;
@@ -173,6 +179,10 @@ export function ChatPageLayout({
   onRemoveImage,
   onImageSelect,
   onClearQuote,
+  isRecording,
+  isVoiceSupported,
+  onVoiceToggle,
+  voiceError,
   onCloseShareModal,
   onCloseCreateProjectModal,
   onSubmitCreateProject,
@@ -229,6 +239,10 @@ export function ChatPageLayout({
     agentName: agentInfo.name,
     quotedText,
     onClearQuote,
+    isRecording,
+    isVoiceSupported,
+    onVoiceToggle,
+    voiceError,
   };
 
   return (

--- a/frontend/app/chat/[sessionId]/hooks/useVoiceInput.ts
+++ b/frontend/app/chat/[sessionId]/hooks/useVoiceInput.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const hasSpeechRecognition =
+  typeof window !== 'undefined' &&
+  ('SpeechRecognition' in window || 'webkitSpeechRecognition' in window);
+
+function resolveLanguage(): string {
+  const lang = (navigator.language ?? '').toLowerCase();
+  if (lang.startsWith('zh')) return 'zh-CN';
+  if (lang.startsWith('en')) return 'en-US';
+  return 'zh-CN';
+}
+
+// Local type definitions for the Web Speech API (not present in all TS DOM libs).
+
+interface SpeechRecognitionAlternative {
+  readonly transcript: string;
+  readonly confidence: number;
+}
+
+interface SpeechRecognitionResultItem {
+  readonly isFinal: boolean;
+  readonly [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number;
+  item(index: number): SpeechRecognitionResultItem;
+  [index: number]: SpeechRecognitionResultItem;
+}
+
+interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number;
+  readonly results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error: string;
+  readonly message: string;
+}
+
+interface SpeechRecognitionInstance {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+  onend: (() => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface UseVoiceInputOptions {
+  /** Called with each confirmed transcript chunk. Appended to the current input value. */
+  onTranscript: (text: string) => void;
+  /** Block recording while a chat response is streaming. */
+  disabled?: boolean;
+}
+
+interface UseVoiceInputResult {
+  isRecording: boolean;
+  isSupported: boolean;
+  toggleRecording: () => void;
+  voiceError: string | null;
+}
+
+export function useVoiceInput({
+  onTranscript,
+  disabled = false,
+}: UseVoiceInputOptions): UseVoiceInputResult {
+  const [isRecording, setIsRecording] = useState(false);
+  const [voiceError, setVoiceError] = useState<string | null>(null);
+  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+
+  // Tear down recognition on unmount.
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.abort();
+    };
+  }, []);
+
+  const startRecording = useCallback(() => {
+    if (!hasSpeechRecognition || disabled) return;
+    setVoiceError(null);
+
+    if (!recognitionRef.current) {
+      const win = window as unknown as {
+        SpeechRecognition?: SpeechRecognitionConstructor;
+        webkitSpeechRecognition?: SpeechRecognitionConstructor;
+      };
+      const SpeechRecognitionImpl = win.SpeechRecognition ?? win.webkitSpeechRecognition;
+      if (!SpeechRecognitionImpl) return;
+
+      const rec = new SpeechRecognitionImpl();
+      rec.continuous = true;      // Keep listening until explicitly stopped.
+      rec.interimResults = false; // Only fire onresult for final segments.
+      rec.lang = resolveLanguage();
+
+      rec.onresult = (event: SpeechRecognitionEvent) => {
+        const results = Array.from({ length: event.results.length }, (_, i) => event.results[i]);
+        const transcript = results
+          .slice(event.resultIndex)
+          .filter((r) => r.isFinal)
+          .map((r) => r[0].transcript)
+          .join('');
+        if (transcript) onTranscript(transcript);
+      };
+
+      rec.onerror = (event: SpeechRecognitionErrorEvent) => {
+        // 'aborted' fires when we call stop() ourselves — not a real error.
+        if (event.error === 'aborted') return;
+        setIsRecording(false);
+        const messages: Record<string, string> = {
+          'not-allowed': '麦克风权限被拒绝，请在浏览器设置中允许访问。',
+          'no-speech': '未检测到语音，请重试。',
+          'network': '语音识别网络错误，请检查网络连接。',
+        };
+        setVoiceError(messages[event.error] ?? `语音识别错误：${event.error}`);
+      };
+
+      rec.onend = () => {
+        // Fires after stop() or a silence timeout.
+        setIsRecording(false);
+      };
+
+      recognitionRef.current = rec;
+    }
+
+    recognitionRef.current.start();
+    setIsRecording(true);
+  }, [disabled, onTranscript]);
+
+  const stopRecording = useCallback(() => {
+    recognitionRef.current?.stop();
+    // isRecording is updated in onend to avoid races.
+  }, []);
+
+  const toggleRecording = useCallback(() => {
+    if (isRecording) {
+      stopRecording();
+    } else {
+      startRecording();
+    }
+  }, [isRecording, startRecording, stopRecording]);
+
+  return {
+    isRecording,
+    isSupported: hasSpeechRecognition,
+    toggleRecording,
+    voiceError,
+  };
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -165,7 +165,23 @@
       radial-gradient(at 0% 100%, hsla(220, 50%, 14%, 1) 0px, transparent 50%);
   }
 
-  .animate-float {
+  /* Mic ripple ring animation */
+  .animate-mic-ripple {
+    animation: micRipple 1.4s ease-out infinite;
+  }
+
+  @keyframes micRipple {
+    0% {
+      transform: scale(1);
+      opacity: 0.5;
+    }
+    100% {
+      transform: scale(2.2);
+      opacity: 0;
+    }
+  }
+
+.animate-float {
     animation: float 6s ease-in-out infinite;
   }
 


### PR DESCRIPTION
## Summary
- Adds `useVoiceInput` hook using Web Speech API for voice recording
- Mic button shows red background with ripple animation while recording
- Inline error messages for mic permission denied, no-speech, and network errors
- Voice props threaded through `ChatPageLayout` → `ChatInput`

## Test plan
- [ ] Click mic button → button turns red with ripple, speech is transcribed into input
- [ ] Click mic again → recording stops, button returns to normal
- [ ] Deny mic permission → error message appears below input