### PR TITLE
refactor(settings): replace inline form with modal dialog for email and SSH configs

### DIFF
--- a/frontend/app/settings/email-servers/page.tsx
+++ b/frontend/app/settings/email-servers/page.tsx
@@ -51,6 +51,16 @@ interface ToastMessage {
   type: ToastType;
 }
 
+const DEFAULT_FORM: FormData = {
+  server: '',
+  smtp_server: '',
+  username: '',
+  password: '',
+  mailbox: 'INBOX',
+  name: '',
+  is_default: false,
+};
+
 export default function EmailServersPage() {
   const router = useRouter();
   const { user, loading } = useAuth();
@@ -60,15 +70,7 @@ export default function EmailServersPage() {
   const [deleteTarget, setDeleteTarget] = useState<EmailServerConfig | null>(null);
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [showPassword, setShowPassword] = useState(false);
-  const [formData, setFormData] = useState<FormData>({
-    server: '',
-    smtp_server: '',
-    username: '',
-    password: '',
-    mailbox: 'INBOX',
-    name: '',
-    is_default: false,
-  });
+  const [formData, setFormData] = useState<FormData>(DEFAULT_FORM);
   const [isLoading, setIsLoading] = useState(false);
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
   const toastId = useRef(0);
@@ -87,10 +89,24 @@ export default function EmailServersPage() {
     }
   }, [user, loading, router]);
 
+  // Close form modal on Escape
   useEffect(() => {
-    if (!deleteTarget) {
-      return;
-    }
+    if (!showForm) return;
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !isLoading) {
+        handleCancel();
+      }
+    };
+
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showForm, isLoading]);
+
+  // Close delete modal on Escape
+  useEffect(() => {
+    if (!deleteTarget) return;
 
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && deletingId === null) {
@@ -111,12 +127,10 @@ export default function EmailServersPage() {
         const data = await response.json();
         setConfigs(data.configs || []);
       } else {
-        const msg = '加载邮件服务器配置失败';
-        notify(msg, 'error');
+        notify('加载邮件服务器配置失败', 'error');
       }
     } catch (err) {
-      const msg = '加载邮件服务器配置失败: ' + (err as Error).message;
-      notify(msg, 'error');
+      notify('加载邮件服务器配置失败: ' + (err as Error).message, 'error');
     }
   }, [notify]);
 
@@ -138,28 +152,21 @@ export default function EmailServersPage() {
 
       const response = await fetch(url, {
         method,
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify(formData),
       });
 
       if (response.ok) {
-        const msg = editingId ? '更新成功' : '添加成功';
-        notify(msg, 'success');
-        setShowForm(false);
-        setEditingId(null);
-        resetForm();
+        notify(editingId ? '更新成功' : '添加成功', 'success');
+        closeForm();
         await loadConfigs();
       } else {
         const data = await response.json();
-        const msg = data.error || '操作失败';
-        notify(msg, 'error');
+        notify(data.error || '操作失败', 'error');
       }
     } catch (err) {
-      const msg = '操作失败: ' + (err as Error).message;
-      notify(msg, 'error');
+      notify('操作失败: ' + (err as Error).message, 'error');
     } finally {
       setIsLoading(false);
     }
@@ -176,8 +183,7 @@ export default function EmailServersPage() {
 
       if (!response.ok) {
         const data = await response.json();
-        const msg = data.error || '加载配置失败';
-        notify(msg, 'error');
+        notify(data.error || '加载配置失败', 'error');
         return;
       }
 
@@ -196,8 +202,7 @@ export default function EmailServersPage() {
       setEditingId(detail.id);
       setShowForm(true);
     } catch (err) {
-      const msg = '加载配置失败: ' + (err as Error).message;
-      notify(msg, 'error');
+      notify('加载配置失败: ' + (err as Error).message, 'error');
     } finally {
       setIsLoading(false);
     }
@@ -208,9 +213,7 @@ export default function EmailServersPage() {
   };
 
   const confirmDelete = async () => {
-    if (!deleteTarget) {
-      return;
-    }
+    if (!deleteTarget) return;
 
     setDeletingId(deleteTarget.id);
     try {
@@ -220,40 +223,33 @@ export default function EmailServersPage() {
       });
 
       if (response.ok) {
-        const msg = '删除成功';
-        notify(msg, 'success');
+        notify('删除成功', 'success');
         setDeleteTarget(null);
         await loadConfigs();
       } else {
         const data = await response.json();
-        const msg = data.error || '删除失败';
-        notify(msg, 'error');
+        notify(data.error || '删除失败', 'error');
       }
     } catch (err) {
-      const msg = '删除失败: ' + (err as Error).message;
-      notify(msg, 'error');
+      notify('删除失败: ' + (err as Error).message, 'error');
     } finally {
       setDeletingId(null);
     }
   };
 
   const resetForm = () => {
-    setFormData({
-      server: '',
-      smtp_server: '',
-      username: '',
-      password: '',
-      mailbox: 'INBOX',
-      name: '',
-      is_default: false,
-    });
+    setFormData(DEFAULT_FORM);
     setEditingId(null);
     setShowPassword(false);
   };
 
-  const handleCancel = () => {
+  const closeForm = () => {
     setShowForm(false);
     resetForm();
+  };
+
+  const handleCancel = () => {
+    closeForm();
   };
 
   if (loading) {
@@ -270,6 +266,178 @@ export default function EmailServersPage() {
 
   return (
     <div className="min-h-screen bg-background">
+      {/* Add / Edit modal */}
+      {showForm && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4 backdrop-blur-sm"
+          onClick={(e) => {
+            if (e.target === e.currentTarget && !isLoading) handleCancel();
+          }}
+        >
+          <div className="w-full max-w-lg overflow-hidden rounded-2xl border bg-background shadow-2xl">
+            <div className="flex items-center justify-between border-b px-6 py-4">
+              <div>
+                <h2 className="text-lg font-semibold">
+                  {editingId ? '编辑' : '添加'}邮件服务器
+                </h2>
+                <p className="text-sm text-muted-foreground mt-0.5">
+                  输入 IMAP/SMTP 服务器信息以查询和发送邮件
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={handleCancel}
+                disabled={isLoading}
+                className="rounded-md p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="px-6 py-5 max-h-[75vh] overflow-y-auto">
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium mb-2">
+                    配置名称 *
+                  </label>
+                  <Input
+                    type="text"
+                    value={formData.name}
+                    onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                    placeholder="例如: 我的 Gmail"
+                    required
+                    autoFocus
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium mb-2">
+                    服务器地址 *
+                  </label>
+                  <Input
+                    type="text"
+                    value={formData.server}
+                    onChange={(e) => setFormData({ ...formData, server: e.target.value })}
+                    placeholder="例如: imap.gmail.com:993"
+                    required
+                  />
+                  <p className="text-xs text-muted-foreground mt-1">
+                    IMAP 服务器地址和端口，通常是 993
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium mb-2">
+                    SMTP 服务器地址
+                  </label>
+                  <Input
+                    type="text"
+                    value={formData.smtp_server}
+                    onChange={(e) => setFormData({ ...formData, smtp_server: e.target.value })}
+                    placeholder="例如: smtp.gmail.com:587"
+                  />
+                  <p className="text-xs text-muted-foreground mt-1">
+                    可选；配置后 AI 助手可使用该账号发送邮件，通常使用 587 或 465 端口
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium mb-2">
+                    邮箱账号 *
+                  </label>
+                  <Input
+                    type="email"
+                    value={formData.username}
+                    onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+                    placeholder="your.email@example.com"
+                    required
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium mb-2">
+                    密码 *
+                  </label>
+                  <div className="relative">
+                    <Input
+                      type={showPassword ? 'text' : 'password'}
+                      value={formData.password}
+                      onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                      placeholder={editingId ? '留空表示不修改' : '邮箱密码或应用专用密码'}
+                      required={!editingId}
+                      className="pr-10"
+                    />
+                    <button
+                      type="button"
+                      className="absolute inset-y-0 right-0 px-3 flex items-center text-muted-foreground hover:text-foreground"
+                      onClick={() => setShowPassword((v) => !v)}
+                    >
+                      {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    建议使用应用专用密码而不是账户密码
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium mb-2">
+                    邮箱文件夹
+                  </label>
+                  <Input
+                    type="text"
+                    value={formData.mailbox}
+                    onChange={(e) => setFormData({ ...formData, mailbox: e.target.value })}
+                    placeholder="INBOX"
+                  />
+                  <p className="text-xs text-muted-foreground mt-1">
+                    默认为 INBOX (收件箱)
+                  </p>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    id="is_default"
+                    checked={formData.is_default}
+                    onChange={(e) => setFormData({ ...formData, is_default: e.target.checked })}
+                    className="rounded"
+                  />
+                  <label htmlFor="is_default" className="text-sm">
+                    设为默认邮箱
+                  </label>
+                </div>
+
+                <div className="flex gap-2 pt-2 border-t">
+                  <Button type="submit" disabled={isLoading}>
+                    {isLoading ? (
+                      <>
+                        <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2"></div>
+                        处理中...
+                      </>
+                    ) : (
+                      <>
+                        <Check className="h-4 w-4 mr-2" />
+                        {editingId ? '更新' : '添加'}
+                      </>
+                    )}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleCancel}
+                    disabled={isLoading}
+                  >
+                    取消
+                  </Button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete confirmation modal */}
       {deleteTarget && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4 backdrop-blur-sm">
           <div className="w-full max-w-md overflow-hidden rounded-2xl border border-red-100 bg-white shadow-2xl">
@@ -322,6 +490,7 @@ export default function EmailServersPage() {
       )}
 
       <div className="container mx-auto px-4 py-8 max-w-4xl">
+        {/* Page header */}
         <div className="mb-6 flex items-center justify-between">
           <div className="flex items-center gap-4">
             <Button
@@ -338,12 +507,10 @@ export default function EmailServersPage() {
               </p>
             </div>
           </div>
-          {!showForm && (
-            <Button onClick={() => setShowForm(true)}>
-              <Plus className="h-4 w-4 mr-2" />
-              添加服务器
-            </Button>
-          )}
+          <Button onClick={() => setShowForm(true)}>
+            <Plus className="h-4 w-4 mr-2" />
+            添加服务器
+          </Button>
         </div>
 
         <Alert className="mb-4 border-yellow-500 bg-yellow-50 dark:bg-yellow-950">
@@ -352,7 +519,7 @@ export default function EmailServersPage() {
           </AlertDescription>
         </Alert>
 
-        {/* Toasts */}
+        {/* Toast notifications */}
         <div className="fixed top-4 right-4 z-50 flex flex-col gap-2 w-80">
           {toasts.map((toast) => {
             const isSuccess = toast.type === 'success';
@@ -374,174 +541,7 @@ export default function EmailServersPage() {
           })}
         </div>
 
-        {showForm && (
-          <Card className="mb-6">
-            <CardHeader>
-              <CardTitle>{editingId ? '编辑' : '添加'}邮件服务器</CardTitle>
-              <CardDescription>
-                输入 IMAP/SMTP 服务器信息以查询和发送邮件
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <form onSubmit={handleSubmit} className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    配置名称 *
-                  </label>
-                  <Input
-                    type="text"
-                    value={formData.name}
-                    onChange={(e) =>
-                      setFormData({ ...formData, name: e.target.value })
-                    }
-                    placeholder="例如: 我的 Gmail"
-                    required
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    服务器地址 *
-                  </label>
-                  <Input
-                    type="text"
-                    value={formData.server}
-                    onChange={(e) =>
-                      setFormData({ ...formData, server: e.target.value })
-                    }
-                    placeholder="例如: imap.gmail.com:993"
-                    required
-                  />
-                  <p className="text-xs text-muted-foreground mt-1">
-                    IMAP 服务器地址和端口，通常是 993
-                  </p>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    SMTP 服务器地址
-                  </label>
-                  <Input
-                    type="text"
-                    value={formData.smtp_server}
-                    onChange={(e) =>
-                      setFormData({ ...formData, smtp_server: e.target.value })
-                    }
-                    placeholder="例如: smtp.gmail.com:587"
-                  />
-                  <p className="text-xs text-muted-foreground mt-1">
-                    可选；配置后 AI 助手可使用该账号发送邮件，通常使用 587 或 465 端口
-                  </p>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    邮箱账号 *
-                  </label>
-                  <Input
-                    type="email"
-                    value={formData.username}
-                    onChange={(e) =>
-                      setFormData({ ...formData, username: e.target.value })
-                    }
-                    placeholder="your.email@example.com"
-                    required
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    密码 *
-                  </label>
-                  <div className="relative">
-                    <Input
-                      type={showPassword ? 'text' : 'password'}
-                      value={formData.password}
-                      onChange={(e) =>
-                        setFormData({ ...formData, password: e.target.value })
-                      }
-                      placeholder={editingId ? '留空表示不修改' : '邮箱密码或应用专用密码'}
-                      required={!editingId}
-                      className="pr-10"
-                    />
-                    <button
-                      type="button"
-                      className="absolute inset-y-0 right-0 px-3 flex items-center text-muted-foreground hover:text-foreground"
-                      onClick={() => setShowPassword((v) => !v)}
-                    >
-                      {showPassword ? (
-                        <EyeOff className="h-4 w-4" />
-                      ) : (
-                        <Eye className="h-4 w-4" />
-                      )}
-                    </button>
-                  </div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    建议使用应用专用密码而不是账户密码
-                  </p>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    邮箱文件夹
-                  </label>
-                  <Input
-                    type="text"
-                    value={formData.mailbox}
-                    onChange={(e) =>
-                      setFormData({ ...formData, mailbox: e.target.value })
-                    }
-                    placeholder="INBOX"
-                  />
-                  <p className="text-xs text-muted-foreground mt-1">
-                    默认为 INBOX (收件箱)
-                  </p>
-                </div>
-
-                <div className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    id="is_default"
-                    checked={formData.is_default}
-                    onChange={(e) =>
-                      setFormData({ ...formData, is_default: e.target.checked })
-                    }
-                    className="rounded"
-                  />
-                  <label htmlFor="is_default" className="text-sm">
-                    设为默认邮箱
-                  </label>
-                </div>
-
-                <div className="flex gap-2 pt-4">
-                  <Button type="submit" disabled={isLoading}>
-                    {isLoading ? (
-                      <>
-                        <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2"></div>
-                        处理中...
-                      </>
-                    ) : (
-                      <>
-                        <Check className="h-4 w-4 mr-2" />
-                        {editingId ? '更新' : '添加'}
-                      </>
-                    )}
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={handleCancel}
-                    disabled={isLoading}
-                  >
-                    <X className="h-4 w-4 mr-2" />
-                    取消
-                  </Button>
-                </div>
-              </form>
-            </CardContent>
-          </Card>
-        )}
-
+        {/* Config list */}
         <div className="space-y-4">
           {configs.length === 0 ? (
             <Card>
@@ -553,12 +553,10 @@ export default function EmailServersPage() {
                 <p className="text-muted-foreground mb-4">
                   添加邮件服务器配置后，AI 助手将能够帮您查询邮件；补充 SMTP 地址后也可发送邮件
                 </p>
-                {!showForm && (
-                  <Button onClick={() => setShowForm(true)}>
-                    <Plus className="h-4 w-4 mr-2" />
-                    添加第一个服务器
-                  </Button>
-                )}
+                <Button onClick={() => setShowForm(true)}>
+                  <Plus className="h-4 w-4 mr-2" />
+                  添加第一个服务器
+                </Button>
               </CardContent>
             </Card>
           ) : (
@@ -568,18 +566,14 @@ export default function EmailServersPage() {
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
                       <div className="flex items-center gap-2">
-                        <CardTitle className="text-lg">
-                          {config.name}
-                        </CardTitle>
+                        <CardTitle className="text-lg">{config.name}</CardTitle>
                         {config.is_default && (
                           <span className="text-xs px-2 py-1 bg-primary text-primary-foreground rounded">
                             默认
                           </span>
                         )}
                       </div>
-                      <CardDescription className="mt-1">
-                        {config.username}
-                      </CardDescription>
+                      <CardDescription className="mt-1">{config.username}</CardDescription>
                     </div>
                     <div className="flex gap-2">
                       <Button

--- a/frontend/app/settings/ssh-servers/page.tsx
+++ b/frontend/app/settings/ssh-servers/page.tsx
@@ -98,10 +98,24 @@ export default function SSHServersPage() {
     }
   }, [user, loading, router]);
 
+  // Close form modal on Escape
   useEffect(() => {
-    if (!deleteTarget) {
-      return;
-    }
+    if (!showForm) return;
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !isLoading) {
+        handleCancel();
+      }
+    };
+
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showForm, isLoading]);
+
+  // Close delete modal on Escape
+  useEffect(() => {
+    if (!deleteTarget) return;
 
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && deletingId === null) {
@@ -154,9 +168,7 @@ export default function SSHServersPage() {
 
       if (response.ok) {
         notify(editingId ? 'Updated successfully' : 'Added successfully', 'success');
-        setShowForm(false);
-        setEditingId(null);
-        resetForm();
+        closeForm();
         await loadConfigs();
       } else {
         const data = await response.json();
@@ -213,9 +225,7 @@ export default function SSHServersPage() {
   };
 
   const confirmDelete = async () => {
-    if (!deleteTarget) {
-      return;
-    }
+    if (!deleteTarget) return;
 
     setDeletingId(deleteTarget.id);
     try {
@@ -246,9 +256,13 @@ export default function SSHServersPage() {
     setShowPassphrase(false);
   };
 
-  const handleCancel = () => {
+  const closeForm = () => {
     setShowForm(false);
     resetForm();
+  };
+
+  const handleCancel = () => {
+    closeForm();
   };
 
   const handleAuthMethodChange = (method: AuthMethod) => {
@@ -271,123 +285,35 @@ export default function SSHServersPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Delete confirmation modal */}
-      {deleteTarget && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4 backdrop-blur-sm">
-          <div className="w-full max-w-md overflow-hidden rounded-2xl border border-red-100 bg-white shadow-2xl">
-            <div className="bg-[linear-gradient(135deg,#fff1f2_0%,#ffffff_65%)] px-6 py-5">
-              <div className="flex items-start gap-4">
-                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-red-100 text-red-600 shadow-sm">
-                  <AlertTriangle className="h-5 w-5" />
-                </div>
-                <div className="space-y-1">
-                  <h2 className="text-lg font-semibold text-slate-900">
-                    Delete SSH server config?
-                  </h2>
-                  <p className="text-sm leading-6 text-slate-600">
-                    This removes the SSH connection for{' '}
-                    <span className="font-medium text-slate-900">{deleteTarget.name}</span>.
-                    The agent will no longer be able to run commands on this server.
-                  </p>
-                </div>
+      {/* Add / Edit modal */}
+      {showForm && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4 backdrop-blur-sm"
+          onClick={(e) => {
+            if (e.target === e.currentTarget && !isLoading) handleCancel();
+          }}
+        >
+          <div className="w-full max-w-lg overflow-hidden rounded-2xl border bg-background shadow-2xl">
+            <div className="flex items-center justify-between border-b px-6 py-4">
+              <div>
+                <h2 className="text-lg font-semibold">
+                  {editingId ? 'Edit' : 'Add'} SSH server
+                </h2>
+                <p className="text-sm text-muted-foreground mt-0.5">
+                  Enter the connection details. The agent will use these credentials to run shell commands.
+                </p>
               </div>
+              <button
+                type="button"
+                onClick={handleCancel}
+                disabled={isLoading}
+                className="rounded-md p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
+              >
+                <X className="h-5 w-5" />
+              </button>
             </div>
 
-            <div className="space-y-4 px-6 py-5">
-              <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
-                <div className="font-medium text-slate-900">{deleteTarget.username}@{deleteTarget.host}</div>
-                <div className="mt-1">Port: {deleteTarget.port}</div>
-              </div>
-
-              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setDeleteTarget(null)}
-                  disabled={deletingId !== null}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  type="button"
-                  variant="destructive"
-                  onClick={confirmDelete}
-                  disabled={deletingId !== null}
-                  className="min-w-28"
-                >
-                  {deletingId === deleteTarget.id ? 'Deleting...' : 'Confirm delete'}
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      <div className="container mx-auto px-4 py-8 max-w-4xl">
-        {/* Page header */}
-        <div className="mb-6 flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => router.push('/chat')}
-            >
-              <ArrowLeft className="h-5 w-5" />
-            </Button>
-            <div>
-              <h1 className="text-3xl font-bold">SSH Server Configs</h1>
-              <p className="text-muted-foreground mt-1">
-                Manage SSH connections the agent can use to run commands
-              </p>
-            </div>
-          </div>
-          {!showForm && (
-            <Button onClick={() => setShowForm(true)}>
-              <Plus className="h-4 w-4 mr-2" />
-              Add server
-            </Button>
-          )}
-        </div>
-
-        <Alert className="mb-4 border-yellow-500 bg-yellow-50 dark:bg-yellow-950">
-          <AlertDescription className="text-yellow-800 dark:text-yellow-200">
-            <strong>Security notice:</strong> Credentials are stored in plain text. Use a
-            dedicated low-privilege account and avoid reusing important passwords or keys.
-          </AlertDescription>
-        </Alert>
-
-        {/* Toast notifications */}
-        <div className="fixed top-4 right-4 z-50 flex flex-col gap-2 w-80">
-          {toasts.map((toast) => {
-            const isSuccess = toast.type === 'success';
-            const isError = toast.type === 'error';
-            const base = 'rounded-md px-4 py-3 shadow-lg text-sm flex items-start gap-2 border';
-            const theme = isSuccess
-              ? 'bg-green-50 text-green-800 border-green-200'
-              : isError
-                ? 'bg-red-50 text-red-800 border-red-200'
-                : 'bg-blue-50 text-blue-800 border-blue-200';
-            return (
-              <div key={toast.id} className={`${base} ${theme}`}>
-                <span className="font-semibold">
-                  {isSuccess ? 'Success' : isError ? 'Error' : 'Info'}
-                </span>
-                <span className="flex-1">{toast.message}</span>
-              </div>
-            );
-          })}
-        </div>
-
-        {/* Add / Edit form */}
-        {showForm && (
-          <Card className="mb-6">
-            <CardHeader>
-              <CardTitle>{editingId ? 'Edit' : 'Add'} SSH server</CardTitle>
-              <CardDescription>
-                Enter the connection details. The agent will use these credentials to run shell commands.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
+            <div className="px-6 py-5 max-h-[75vh] overflow-y-auto">
               <form onSubmit={handleSubmit} className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium mb-2">
@@ -399,6 +325,7 @@ export default function SSHServersPage() {
                     onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                     placeholder="e.g. My dev server"
                     required
+                    autoFocus
                   />
                 </div>
 
@@ -500,11 +427,7 @@ export default function SSHServersPage() {
                         className="absolute inset-y-0 right-0 px-3 flex items-center text-muted-foreground hover:text-foreground"
                         onClick={() => setShowPassword((v) => !v)}
                       >
-                        {showPassword ? (
-                          <EyeOff className="h-4 w-4" />
-                        ) : (
-                          <Eye className="h-4 w-4" />
-                        )}
+                        {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                       </button>
                     </div>
                   </div>
@@ -551,11 +474,7 @@ export default function SSHServersPage() {
                           className="absolute inset-y-0 right-0 px-3 flex items-center text-muted-foreground hover:text-foreground"
                           onClick={() => setShowPassphrase((v) => !v)}
                         >
-                          {showPassphrase ? (
-                            <EyeOff className="h-4 w-4" />
-                          ) : (
-                            <Eye className="h-4 w-4" />
-                          )}
+                          {showPassphrase ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                         </button>
                       </div>
                     </div>
@@ -575,7 +494,7 @@ export default function SSHServersPage() {
                   </label>
                 </div>
 
-                <div className="flex gap-2 pt-4">
+                <div className="flex gap-2 pt-2 border-t">
                   <Button type="submit" disabled={isLoading}>
                     {isLoading ? (
                       <>
@@ -595,14 +514,119 @@ export default function SSHServersPage() {
                     onClick={handleCancel}
                     disabled={isLoading}
                   >
-                    <X className="h-4 w-4 mr-2" />
                     Cancel
                   </Button>
                 </div>
               </form>
-            </CardContent>
-          </Card>
-        )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete confirmation modal */}
+      {deleteTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4 backdrop-blur-sm">
+          <div className="w-full max-w-md overflow-hidden rounded-2xl border border-red-100 bg-white shadow-2xl">
+            <div className="bg-[linear-gradient(135deg,#fff1f2_0%,#ffffff_65%)] px-6 py-5">
+              <div className="flex items-start gap-4">
+                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-red-100 text-red-600 shadow-sm">
+                  <AlertTriangle className="h-5 w-5" />
+                </div>
+                <div className="space-y-1">
+                  <h2 className="text-lg font-semibold text-slate-900">
+                    Delete SSH server config?
+                  </h2>
+                  <p className="text-sm leading-6 text-slate-600">
+                    This removes the SSH connection for{' '}
+                    <span className="font-medium text-slate-900">{deleteTarget.name}</span>.
+                    The agent will no longer be able to run commands on this server.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-4 px-6 py-5">
+              <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+                <div className="font-medium text-slate-900">{deleteTarget.username}@{deleteTarget.host}</div>
+                <div className="mt-1">Port: {deleteTarget.port}</div>
+              </div>
+
+              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setDeleteTarget(null)}
+                  disabled={deletingId !== null}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={confirmDelete}
+                  disabled={deletingId !== null}
+                  className="min-w-28"
+                >
+                  {deletingId === deleteTarget.id ? 'Deleting...' : 'Confirm delete'}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        {/* Page header */}
+        <div className="mb-6 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => router.push('/chat')}
+            >
+              <ArrowLeft className="h-5 w-5" />
+            </Button>
+            <div>
+              <h1 className="text-3xl font-bold">SSH Server Configs</h1>
+              <p className="text-muted-foreground mt-1">
+                Manage SSH connections the agent can use to run commands
+              </p>
+            </div>
+          </div>
+          <Button onClick={() => setShowForm(true)}>
+            <Plus className="h-4 w-4 mr-2" />
+            Add server
+          </Button>
+        </div>
+
+        <Alert className="mb-4 border-yellow-500 bg-yellow-50 dark:bg-yellow-950">
+          <AlertDescription className="text-yellow-800 dark:text-yellow-200">
+            <strong>Security notice:</strong> Credentials are stored in plain text. Use a
+            dedicated low-privilege account and avoid reusing important passwords or keys.
+          </AlertDescription>
+        </Alert>
+
+        {/* Toast notifications */}
+        <div className="fixed top-4 right-4 z-50 flex flex-col gap-2 w-80">
+          {toasts.map((toast) => {
+            const isSuccess = toast.type === 'success';
+            const isError = toast.type === 'error';
+            const base = 'rounded-md px-4 py-3 shadow-lg text-sm flex items-start gap-2 border';
+            const theme = isSuccess
+              ? 'bg-green-50 text-green-800 border-green-200'
+              : isError
+                ? 'bg-red-50 text-red-800 border-red-200'
+                : 'bg-blue-50 text-blue-800 border-blue-200';
+            return (
+              <div key={toast.id} className={`${base} ${theme}`}>
+                <span className="font-semibold">
+                  {isSuccess ? 'Success' : isError ? 'Error' : 'Info'}
+                </span>
+                <span className="flex-1">{toast.message}</span>
+              </div>
+            );
+          })}
+        </div>
 
         {/* Config list */}
         <div className="space-y-4">
@@ -614,12 +638,10 @@ export default function SSHServersPage() {
                 <p className="text-muted-foreground mb-4">
                   Add an SSH server so the agent can run shell commands on your machines.
                 </p>
-                {!showForm && (
-                  <Button onClick={() => setShowForm(true)}>
-                    <Plus className="h-4 w-4 mr-2" />
-                    Add your first server
-                  </Button>
-                )}
+                <Button onClick={() => setShowForm(true)}>
+                  <Plus className="h-4 w-4 mr-2" />
+                  Add your first server
+                </Button>
               </CardContent>
             </Card>
           ) : (


### PR DESCRIPTION
## Summary

- The add/edit form on both settings pages previously appeared inline above the list, causing layout shifts and losing visual context of which item was being edited
- Replace with a centered modal dialog on both `email-servers` and `ssh-servers` pages
- The list remains fully visible and stable at all times — no more scrolling up to fill the form then back down to check the list

## Changes

- Form opens as a focused modal overlay with backdrop blur
- Click-outside or Escape key closes the form modal
- `×` close button in the modal header
- Form body is scrollable (`max-h-[75vh]`) to handle tall content like the SSH private key textarea
- `autoFocus` on the first input for immediate keyboard entry
- "Add server" button always shown in the page header (was conditionally hidden before)
- Empty-state CTA button no longer conditionally hidden either
- Extracted `closeForm()` helper and `DEFAULT_FORM` constant for cleaner code

## Test plan

- [ ] Email servers: click "Add server" → modal opens with empty form → submit → modal closes, item appears in list
- [ ] Email servers: click Edit on an existing item → modal opens pre-filled → update → modal closes, list reflects change
- [ ] SSH servers: same add/edit flow
- [ ] SSH servers: auth method toggle (Password ↔ Public key) works inside modal
- [ ] Escape key closes the form modal
- [ ] Clicking the backdrop closes the form modal
- [ ] Delete confirmation modal still works on both pages