### PR TITLE
feat(assistant): add streaming TTS with server-side sentence chunking

### DIFF
--- a/frontend/app/chat/[sessionId]/components/MessageContent.tsx
+++ b/frontend/app/chat/[sessionId]/components/MessageContent.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, memo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Button } from '@/app/components/ui/button';
 import { Code2, Eye, Copy, Check, X, ChevronDown, ChevronRight, RotateCcw } from 'lucide-react';
+import { TTSButton } from './TTSButton';
 import { cn } from '@/app/lib/utils';
 import { markdownRemarkPlugins, markdownRehypePlugins, markdownComponents, preprocessMarkdown } from '../utils/markdown';
 import { FEEDBACK_TIMEOUT_MS } from '../constants';
@@ -10,6 +11,7 @@ import type { ToolCallItem } from '../types';
 interface AIMessageContentProps {
   content: string;
   thought?: string;
+  id?: string;
   isStreaming?: boolean;
   images?: string[];
   isError?: boolean;
@@ -21,6 +23,7 @@ interface AIMessageContentProps {
 export const AIMessageContent = memo(({
   content,
   thought,
+  id,
   isStreaming,
   images,
   isError,
@@ -29,6 +32,7 @@ export const AIMessageContent = memo(({
   toolCalls,
 }: AIMessageContentProps) => {
   const [showRaw, setShowRaw] = useState(false);
+  const [ttsActive, setTtsActive] = useState(false);
   const [expandedToolCallIndexes, setExpandedToolCallIndexes] = useState<number[]>([]);
   const [isThoughtExpanded, setIsThoughtExpanded] = useState(() => {
     if (!thought || !thoughtStorageKey || typeof window === 'undefined') return false;
@@ -287,7 +291,8 @@ export const AIMessageContent = memo(({
         {!isStreaming && (
           <div className={cn(
             "flex gap-1 mt-2 transition-opacity duration-200",
-            isError ? "opacity-100" : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+            isError ? "opacity-100" : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
+            ttsActive && "opacity-100"
           )}>
             {isError ? (
               onRetry && (
@@ -304,6 +309,9 @@ export const AIMessageContent = memo(({
               )
             ) : (
               <>
+                {content && (
+                  <TTSButton text={content} messageId={id || 'unknown'} isStreaming={isStreaming} onActiveChange={setTtsActive} />
+                )}
                 <Button
                   size="sm"
                   variant="ghost"

--- a/frontend/app/chat/[sessionId]/components/TTSButton.tsx
+++ b/frontend/app/chat/[sessionId]/components/TTSButton.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback, memo } from 'react';
+import { Button } from '@/app/components/ui/button';
+import { Volume2, Square } from 'lucide-react';
+import { useAuth } from '@/app/contexts/AuthContext';
+
+interface TTSButtonProps {
+  text: string;
+  messageId: string;
+  isStreaming?: boolean;
+  /** Called with true when a TTS job starts (loading or playing), false when it ends. */
+  onActiveChange?: (active: boolean) => void;
+}
+
+export const TTSButton = memo(({
+  text,
+  messageId,
+  isStreaming,
+  onActiveChange,
+}: TTSButtonProps) => {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const audioRef = useRef<HTMLAudioElement>(null);
+  // Queue of blob URLs waiting to be played.
+  const queueRef = useRef<string[]>([]);
+  // Whether the stream is still producing chunks.
+  const streamingRef = useRef(false);
+  // Object URLs that need to be revoked on cleanup.
+  const allObjectURLs = useRef<string[]>([]);
+  // AbortController to cancel the fetch when the user stops.
+  const abortRef = useRef<AbortController | null>(null);
+
+  const { authenticatedFetch } = useAuth();
+
+  // Revoke all object URLs on unmount.
+  useEffect(() => {
+    return () => {
+      allObjectURLs.current.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, []);
+
+  // Play the next chunk in the queue, if any.
+  const playNext = useCallback(() => {
+    if (!audioRef.current) return;
+
+    const next = queueRef.current.shift();
+    if (next) {
+      audioRef.current.src = next;
+      audioRef.current.play().catch((err) => {
+        console.error('TTS playback error:', err);
+      });
+    } else if (!streamingRef.current) {
+      // Queue is empty and stream is done — playback complete.
+      setIsPlaying(false);
+      onActiveChange?.(false);
+    }
+    // If queue is empty but stream is still going, `handleEnded` will be called
+    // again once more chunks arrive and get pushed to the queue.
+  }, [onActiveChange]);
+
+  const stop = useCallback(() => {
+    // Cancel the in-flight SSE request.
+    abortRef.current?.abort();
+    abortRef.current = null;
+    streamingRef.current = false;
+
+    // Revoke queued URLs.
+    queueRef.current.forEach((url) => URL.revokeObjectURL(url));
+    queueRef.current = [];
+
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.src = '';
+    }
+
+    setIsPlaying(false);
+    setIsLoading(false);
+    onActiveChange?.(false);
+  }, [onActiveChange]);
+
+  const handlePlayAudio = async () => {
+    if (isPlaying || isLoading) {
+      stop();
+      return;
+    }
+
+    // Unlock autoplay within the user-gesture window before any async work.
+    if (audioRef.current) {
+      audioRef.current.play().catch(() => {});
+      audioRef.current.pause();
+    }
+
+    setIsLoading(true);
+    setError(null);
+    onActiveChange?.(true);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    streamingRef.current = true;
+    queueRef.current = [];
+
+    try {
+      const response = await authenticatedFetch('/api/assistant/tts/stream', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, voice_name: 'Kore' }),
+        signal: controller.signal,
+      } as RequestInit);
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error || `TTS request failed (${response.status})`);
+      }
+
+      if (!response.body) {
+        throw new Error('No response body');
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let firstChunk = true;
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // SSE events are separated by double newlines.
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() ?? '';
+
+        for (const part of parts) {
+          const lines = part.split('\n');
+          let eventType = 'message';
+          let dataLine = '';
+
+          for (const line of lines) {
+            if (line.startsWith('event:')) {
+              eventType = line.slice(6).trim();
+            } else if (line.startsWith('data:')) {
+              dataLine = line.slice(5).trim();
+            }
+          }
+
+          if (!dataLine) continue;
+
+          let payload: Record<string, unknown>;
+          try {
+            payload = JSON.parse(dataLine);
+          } catch {
+            continue;
+          }
+
+          if (eventType === 'error') {
+            throw new Error(String(payload.error ?? 'TTS stream error'));
+          }
+
+          if (eventType === 'done') {
+            streamingRef.current = false;
+            // If the audio element has already finished the last queued chunk,
+            // it will be idle now — trigger a final check.
+            if (!audioRef.current?.src || audioRef.current.ended || audioRef.current.paused) {
+              playNext();
+            }
+            break;
+          }
+
+          if (eventType === 'chunk' && typeof payload.data === 'string') {
+            // Decode base64 WAV.
+            const binary = atob(payload.data);
+            const bytes = new Uint8Array(binary.length);
+            for (let i = 0; i < binary.length; i++) {
+              bytes[i] = binary.charCodeAt(i);
+            }
+            const blob = new Blob([bytes], { type: 'audio/wav' });
+            const objectURL = URL.createObjectURL(blob);
+            allObjectURLs.current.push(objectURL);
+
+            if (firstChunk) {
+              firstChunk = false;
+              setIsLoading(false);
+              setIsPlaying(true);
+              // Play immediately.
+              if (audioRef.current) {
+                audioRef.current.src = objectURL;
+                audioRef.current.play().catch((err) => {
+                  console.error('TTS first-chunk playback error:', err);
+                });
+              }
+            } else {
+              queueRef.current.push(objectURL);
+              // If the audio element finished a previous chunk while the queue
+              // was empty (slow network), it will be paused/ended with a stale
+              // src. Resume immediately now that a new chunk has arrived.
+              if (audioRef.current && (audioRef.current.ended || audioRef.current.paused)) {
+                playNext();
+              }
+            }
+          }
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') return; // user stopped
+      const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+      console.error('TTS error:', errorMessage);
+      setError(errorMessage);
+      setIsPlaying(false);
+      setIsLoading(false);
+      onActiveChange?.(false);
+    } finally {
+      streamingRef.current = false;
+    }
+  };
+
+  // When a chunk finishes playing, move to the next one.
+  const handleEnded = useCallback(() => {
+    if (queueRef.current.length > 0) {
+      playNext();
+    } else if (!streamingRef.current) {
+      // No more chunks and stream is done.
+      setIsPlaying(false);
+      onActiveChange?.(false);
+    }
+    // Otherwise the stream is still running; wait for next chunk to be pushed.
+  }, [playNext, onActiveChange]);
+
+  const isDisabled = isStreaming || !text?.trim();
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={handlePlayAudio}
+        disabled={isDisabled}
+        className="h-6 w-6 p-0 hover:bg-secondary text-muted-foreground hover:text-foreground"
+        title={isPlaying || isLoading ? 'Stop audio' : error ? 'TTS error' : 'Play audio'}
+        aria-label={isPlaying || isLoading ? 'Stop audio' : 'Play audio'}
+      >
+        {isPlaying || isLoading ? (
+          <Square className="h-3.5 w-3.5" />
+        ) : (
+          <Volume2 className={`h-3.5 w-3.5 ${error ? 'text-red-500' : ''}`} />
+        )}
+      </Button>
+      <audio ref={audioRef} onEnded={handleEnded} />
+    </>
+  );
+});
+
+TTSButton.displayName = 'TTSButton';

--- a/internal/app/aiguide/assistant/tts_api.go
+++ b/internal/app/aiguide/assistant/tts_api.go
@@ -1,0 +1,303 @@
+package assistant
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/gin-gonic/gin"
+	"google.golang.org/genai"
+)
+
+const (
+	// TTSModel is the Gemini TTS model identifier.
+	TTSModel = "gemini-2.5-flash-preview-tts"
+	// TTSMaxTextLength is the max character limit for TTS requests.
+	TTSMaxTextLength = 10000
+	// TTSMaxChunkLen is the max characters per sentence chunk sent to Gemini.
+	TTSMaxChunkLen = 200
+)
+
+// TTSRequest defines the request body for text-to-speech conversion.
+type TTSRequest struct {
+	Text      string `json:"text"`
+	VoiceName string `json:"voice_name,omitempty"` // e.g. "Kore", "Puck", "Charon". Defaults to "Kore".
+}
+
+// TextToSpeechStream splits the input text into sentence-level chunks, calls
+// Gemini TTS for each chunk sequentially, and streams the resulting WAV audio
+// back to the client as Server-Sent Events.
+//
+// Each SSE event has type "chunk" and a JSON payload:
+//
+//	{"index": <int>, "data": "<base64-encoded WAV>"}
+//
+// A final event of type "done" is sent when all chunks have been processed.
+// On error, an event of type "error" is sent with {"error": "<message>"}.
+//
+// POST /api/assistant/tts/stream
+func (a *Assistant) TextToSpeechStream(ctx *gin.Context) {
+	// 1. Authenticate
+	userID, ok := getContextUserID(ctx)
+	if !ok || userID <= 0 {
+		slog.Error("TextToSpeechStream: invalid or missing user_id in context")
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	// 2. Parse and validate request
+	var req TTSRequest
+	if err := ctx.BindJSON(&req); err != nil {
+		slog.Error("TextToSpeechStream: ctx.BindJSON() error", "err", err)
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	req.Text = strings.TrimSpace(req.Text)
+	if req.Text == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "text cannot be empty"})
+		return
+	}
+	if len(req.Text) > TTSMaxTextLength {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("text too long (max %d characters)", TTSMaxTextLength)})
+		return
+	}
+	if req.VoiceName == "" {
+		req.VoiceName = "Kore"
+	}
+
+	// 3. Split text into sentence chunks
+	chunks := splitSentences(req.Text, TTSMaxChunkLen)
+	if len(chunks) == 0 {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "text cannot be empty"})
+		return
+	}
+
+	slog.Debug("TextToSpeechStream: starting",
+		"chunks", len(chunks),
+		"voice", req.VoiceName,
+		"user_id", userID,
+	)
+
+	// 4. Set up SSE response
+	ctx.Writer.Header().Set("Content-Type", "text/event-stream")
+	ctx.Writer.Header().Set("Cache-Control", "no-cache")
+	ctx.Writer.Header().Set("Connection", "keep-alive")
+	ctx.Writer.Header().Set("Content-Encoding", "none")
+	ctx.Writer.Flush()
+
+	// 5. Generate and stream each chunk
+	for i, chunk := range chunks {
+		// Check if client disconnected
+		select {
+		case <-ctx.Request.Context().Done():
+			slog.Debug("TextToSpeechStream: client disconnected", "chunk", i)
+			return
+		default:
+		}
+
+		wavData, err := a.generateTTSChunk(ctx, chunk, req.VoiceName)
+		if err != nil {
+			slog.Error("TextToSpeechStream: generateTTSChunk error", "chunk", i, "err", err)
+			ctx.SSEvent("error", gin.H{"error": fmt.Sprintf("failed to generate chunk %d: %s", i, err.Error())})
+			ctx.Writer.Flush()
+			return
+		}
+
+		slog.Info("TextToSpeechStream: chunk ready",
+			"index", i,
+			"wav_bytes", len(wavData),
+			"user_id", userID,
+		)
+
+		ctx.SSEvent("chunk", gin.H{
+			"index": i,
+			"total": len(chunks),
+			"data":  base64.StdEncoding.EncodeToString(wavData),
+		})
+		ctx.Writer.Flush()
+	}
+
+	ctx.SSEvent("done", gin.H{"total": len(chunks)})
+	ctx.Writer.Flush()
+
+	slog.Info("TextToSpeechStream: completed",
+		"user_id", userID,
+		"chunks", len(chunks),
+	)
+}
+
+// generateTTSChunk calls Gemini TTS for a single text chunk and returns WAV bytes.
+func (a *Assistant) generateTTSChunk(ctx *gin.Context, text, voiceName string) ([]byte, error) {
+	ttsResp, err := a.genaiClient.Models.GenerateContent(
+		ctx,
+		TTSModel,
+		genai.Text(text),
+		&genai.GenerateContentConfig{
+			ResponseModalities: []string{"AUDIO"},
+			SpeechConfig: &genai.SpeechConfig{
+				VoiceConfig: &genai.VoiceConfig{
+					PrebuiltVoiceConfig: &genai.PrebuiltVoiceConfig{
+						VoiceName: voiceName,
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("genaiClient.Models.GenerateContent() error: %w", err)
+	}
+
+	if len(ttsResp.Candidates) == 0 || ttsResp.Candidates[0].Content == nil {
+		return nil, fmt.Errorf("empty candidates from Gemini TTS")
+	}
+
+	var rawData []byte
+	responseMIME := ""
+	for _, part := range ttsResp.Candidates[0].Content.Parts {
+		if part.InlineData != nil && len(part.InlineData.Data) > 0 {
+			rawData = part.InlineData.Data
+			responseMIME = part.InlineData.MIMEType
+			break
+		}
+	}
+
+	if len(rawData) == 0 {
+		return nil, fmt.Errorf("no audio data in Gemini TTS response")
+	}
+
+	return pcmToWAV(rawData, responseMIME), nil
+}
+
+// splitSentences splits text into chunks at sentence boundaries (。！？!?\n),
+// keeping each chunk under maxLen characters. If a sentence exceeds maxLen it
+// is split at the nearest word/character boundary.
+func splitSentences(text string, maxLen int) []string {
+	// Sentence-ending punctuation (Chinese and ASCII).
+	isSentenceEnd := func(r rune) bool {
+		switch r {
+		case '。', '！', '？', '!', '?', '\n', '…':
+			return true
+		}
+		return false
+	}
+
+	var chunks []string
+	runes := []rune(text)
+	start := 0
+
+	for start < len(runes) {
+		// Find the next sentence boundary within maxLen.
+		end := start
+		lastBoundary := -1
+
+		for end < len(runes) && end-start < maxLen {
+			if isSentenceEnd(runes[end]) {
+				lastBoundary = end + 1 // include the punctuation
+			}
+			end++
+		}
+
+		var chunk string
+		if end >= len(runes) {
+			// Reached end of text.
+			chunk = string(runes[start:end])
+			start = end
+		} else if lastBoundary > start {
+			// Cut at the last sentence boundary within maxLen.
+			chunk = string(runes[start:lastBoundary])
+			start = lastBoundary
+		} else {
+			// No sentence boundary found; cut at a space or hard-cut.
+			cutAt := start + maxLen
+			for cutAt > start && !unicode.IsSpace(runes[cutAt-1]) {
+				cutAt--
+			}
+			if cutAt == start {
+				cutAt = start + maxLen // no space found, hard-cut
+			}
+			chunk = string(runes[start:cutAt])
+			start = cutAt
+		}
+
+		chunk = strings.TrimSpace(chunk)
+		if chunk != "" {
+			chunks = append(chunks, chunk)
+		}
+	}
+
+	return chunks
+}
+
+// pcmToWAV parses sample-rate / channel info from the Gemini MIME type and
+// wraps the raw PCM bytes in a standard RIFF/WAV container.
+// If the data is already a known container format it is returned unchanged.
+func pcmToWAV(raw []byte, mimeType string) []byte {
+	lower := strings.ToLower(mimeType)
+
+	// Already a container format — pass through as-is.
+	if strings.Contains(lower, "wav") ||
+		strings.Contains(lower, "mp3") || strings.Contains(lower, "mpeg") ||
+		strings.Contains(lower, "ogg") ||
+		strings.Contains(lower, "aac") {
+		return raw
+	}
+
+	// Parse "audio/l16; rate=24000; channels=1"
+	sampleRate := uint32(24000)
+	numChannels := uint16(1)
+
+	for _, param := range strings.Split(mimeType, ";") {
+		param = strings.TrimSpace(param)
+		if v, ok := strings.CutPrefix(param, "rate="); ok {
+			if n, err := strconv.ParseUint(strings.TrimSpace(v), 10, 32); err == nil {
+				sampleRate = uint32(n)
+			}
+		}
+		if v, ok := strings.CutPrefix(param, "channels="); ok {
+			if n, err := strconv.ParseUint(strings.TrimSpace(v), 10, 16); err == nil {
+				numChannels = uint16(n)
+			}
+		}
+	}
+
+	return buildWAV(raw, sampleRate, numChannels, 16)
+}
+
+// buildWAV wraps raw signed-16-bit little-endian PCM in a RIFF/WAV container.
+func buildWAV(pcm []byte, sampleRate uint32, numChannels uint16, bitsPerSample uint16) []byte {
+	const headerSize = 44
+	byteRate := sampleRate * uint32(numChannels) * uint32(bitsPerSample) / 8
+	blockAlign := numChannels * bitsPerSample / 8
+	dataSize := uint32(len(pcm))
+	chunkSize := uint32(headerSize-8) + dataSize
+
+	buf := make([]byte, headerSize+len(pcm))
+
+	// RIFF chunk descriptor
+	copy(buf[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(buf[4:8], chunkSize)
+	copy(buf[8:12], "WAVE")
+
+	// fmt sub-chunk
+	copy(buf[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(buf[16:20], 16) // PCM fmt chunk is always 16 bytes
+	binary.LittleEndian.PutUint16(buf[20:22], 1)  // audio format: 1 = PCM
+	binary.LittleEndian.PutUint16(buf[22:24], numChannels)
+	binary.LittleEndian.PutUint32(buf[24:28], sampleRate)
+	binary.LittleEndian.PutUint32(buf[28:32], byteRate)
+	binary.LittleEndian.PutUint16(buf[32:34], blockAlign)
+	binary.LittleEndian.PutUint16(buf[34:36], bitsPerSample)
+
+	// data sub-chunk
+	copy(buf[36:40], "data")
+	binary.LittleEndian.PutUint32(buf[40:44], dataSize)
+	copy(buf[44:], pcm)
+
+	return buf
+}

--- a/internal/app/aiguide/router.go
+++ b/internal/app/aiguide/router.go
@@ -41,6 +41,9 @@ func (a *AIGuide) initRouter(engine *gin.Engine) error {
 	// Agent 聊天路由
 	api.POST("/assistant/chats/:id", a.assistant.Chat)
 
+	// Text-to-speech streaming endpoint
+	api.POST("/assistant/tts/stream", a.assistant.TextToSpeechStream)
+
 	// Share management routes (authenticated)
 	shareGroup := api.Group("/assistant/share")
 	{


### PR DESCRIPTION
## Summary

- Add `POST /api/assistant/tts/stream` endpoint: splits input text at sentence boundaries (`。！？!?\n`), calls Gemini TTS (`gemini-2.5-flash-preview-tts`) per chunk sequentially, and streams WAV audio back as SSE `chunk` events (base64-encoded)
- Frontend (`TTSButton`) reads the SSE stream, plays the first chunk immediately (no waiting for full generation), and queues subsequent chunks for gapless sequential playback via an `onEnded` → `playNext` chain
- Fix chunk stall race condition: when a new SSE chunk arrives and the audio element is already idle from a finished previous chunk, `playNext()` is called immediately
- Use `AbortController` to cancel the in-flight stream when the user clicks stop
- Revoke all blob URLs on unmount to prevent memory leaks
- Action bar stays visible while TTS is active via `ttsActive` state lifted from `TTSButton` to `MessageContent`

## Test plan

- [ ] Click speaker icon on an AI message — audio starts playing within a few seconds (first chunk)
- [ ] Audio continues playing through all chunks without gaps
- [ ] Click stop (■) mid-playback — stream cancels and audio stops immediately
- [ ] Click speaker again after stopping — restarts from the beginning
- [ ] Long responses split into multiple chunks play end-to-end
- [ ] No memory leaks: blob URLs are revoked on component unmount