### PR TITLE
Fix user message text overflow and rendering

### DIFF
--- a/frontend/app/chat/[sessionId]/components/ChatMessagesPane.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatMessagesPane.tsx
@@ -113,7 +113,7 @@ export const ChatMessagesPane = memo(function ChatMessagesPane({
             key={message.id}
             ref={message.role === 'user' && message.id === latestUserMessageId ? latestUserMessageRef : undefined}
             className={cn(
-              'flex w-full group/message',
+              'flex w-full min-w-0 group/message',
               index > 0 && (isUserToAssistantPair ? 'mt-3 sm:mt-4' : 'mt-6 sm:mt-8'),
               message.role === 'user' ? 'justify-end' : 'justify-start'
             )}
@@ -135,10 +135,10 @@ export const ChatMessagesPane = memo(function ChatMessagesPane({
               </div>
             </div>
           ) : (
-            <div className="flex gap-2 sm:gap-3 md:gap-4 max-w-[95%] sm:max-w-[90%] md:max-w-[85%] flex-row-reverse">
+            <div className="flex gap-2 sm:gap-3 md:gap-4 max-w-[95%] sm:max-w-[90%] md:max-w-[85%] min-w-0 flex-row-reverse">
               <UserAvatar user={user} />
-              <div className="relative flex flex-col items-end">
-                <div className="relative w-full min-w-0 max-w-full overflow-hidden rounded-2xl rounded-tr-sm bg-zinc-100 px-4 py-2.5 text-sm leading-relaxed dark:bg-zinc-800 sm:min-w-[180px] sm:w-fit">
+              <div className="relative flex flex-col items-end min-w-0 overflow-hidden">
+                <div className="relative w-full min-w-0 max-w-full overflow-hidden rounded-2xl rounded-tr-sm bg-zinc-100 px-4 py-2.5 text-sm leading-relaxed dark:bg-zinc-800 sm:min-w-[180px]">
                   {editingMessageId === message.id ? (
                     <div className="space-y-3">
                       <div className="relative">

--- a/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
@@ -266,7 +266,7 @@ export function ChatPageLayout({
         onMobileToggle={onToggleMobileSidebar}
       />
 
-      <div className="flex flex-col flex-1 h-full min-w-0 md:pl-[260px] relative transition-all duration-300 overflow-hidden">
+      <div className="flex flex-col flex-1 h-full min-w-0 md:pl-[260px] relative transition-all duration-300 overflow-x-hidden">
         <div className="md:hidden fixed top-3 left-3 z-30">
           <Button
             onClick={onOpenMobileSidebar}
@@ -294,12 +294,12 @@ export function ChatPageLayout({
           <>
             <div
               ref={scrollContainerRef}
-              className="flex-1 overflow-hidden overflow-y-auto no-scrollbar mobile-scroll min-w-0"
+              className="flex-1 overflow-x-hidden overflow-y-auto no-scrollbar mobile-scroll min-w-0"
               onScroll={onScroll}
             >
-              <div className="flex flex-col items-center overflow-hidden min-w-0 w-full">
+              <div className="flex flex-col items-center min-w-0 w-full">
                 <div
-                  className="w-full max-w-5xl px-3 sm:px-4 md:px-6 pt-6 sm:pt-8 md:pt-10 overflow-hidden min-w-0 mx-auto"
+                  className="w-full max-w-5xl px-3 sm:px-4 md:px-6 pt-6 sm:pt-8 md:pt-10 min-w-0 mx-auto"
                   style={{ paddingBottom: `${Math.max(16, chatInputOffset + COMPOSER_MESSAGE_GAP)}px` }}
                 >
                   <ChatMessagesPane {...messagesPaneProps} />

--- a/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
@@ -246,7 +246,7 @@ export function ChatPageLayout({
   };
 
   return (
-    <div className="flex h-screen bg-background font-sans text-foreground">
+    <div className="flex h-screen bg-background font-sans text-foreground overflow-hidden">
       <SessionSidebar
         sessions={sessions}
         projects={projects}
@@ -266,7 +266,7 @@ export function ChatPageLayout({
         onMobileToggle={onToggleMobileSidebar}
       />
 
-      <div className="flex flex-col flex-1 h-full md:pl-[260px] relative transition-all duration-300">
+      <div className="flex flex-col flex-1 h-full min-w-0 md:pl-[260px] relative transition-all duration-300 overflow-hidden">
         <div className="md:hidden fixed top-3 left-3 z-30">
           <Button
             onClick={onOpenMobileSidebar}
@@ -294,12 +294,12 @@ export function ChatPageLayout({
           <>
             <div
               ref={scrollContainerRef}
-              className="flex-1 overflow-y-auto no-scrollbar mobile-scroll"
+              className="flex-1 overflow-hidden overflow-y-auto no-scrollbar mobile-scroll min-w-0"
               onScroll={onScroll}
             >
-              <div className="flex flex-col items-center">
+              <div className="flex flex-col items-center overflow-hidden min-w-0 w-full">
                 <div
-                  className="w-full max-w-5xl px-3 sm:px-4 md:px-6 pt-6 sm:pt-8 md:pt-10"
+                  className="w-full max-w-5xl px-3 sm:px-4 md:px-6 pt-6 sm:pt-8 md:pt-10 overflow-hidden min-w-0 mx-auto"
                   style={{ paddingBottom: `${Math.max(16, chatInputOffset + COMPOSER_MESSAGE_GAP)}px` }}
                 >
                   <ChatMessagesPane {...messagesPaneProps} />

--- a/frontend/app/chat/[sessionId]/components/MessageContent.tsx
+++ b/frontend/app/chat/[sessionId]/components/MessageContent.tsx
@@ -291,7 +291,7 @@ export const AIMessageContent = memo(({
             {content}
           </pre>
         ) : (
-          <div className="prose prose-sm prose-zinc dark:prose-invert max-w-none prose-p:leading-relaxed prose-p:my-3 prose-pre:p-0 prose-pre:rounded-lg prose-headings:my-4 prose-headings:font-semibold prose-table:border-collapse prose-table:w-full prose-th:border prose-td:border prose-th:border-border prose-td:border-border prose-th:bg-muted/60 prose-th:px-3 prose-th:py-2 prose-td:px-3 prose-td:py-2 break-words [overflow-wrap:anywhere]">
+          <div className="prose prose-sm prose-zinc dark:prose-invert max-w-none prose-p:leading-relaxed prose-p:my-1 prose-pre:p-0 prose-pre:rounded-lg prose-pre:overflow-x-auto prose-headings:my-4 prose-headings:font-semibold prose-table:border-collapse prose-table:w-full prose-th:border prose-td:border prose-th:border-border prose-td:border-border prose-th:bg-muted/60 prose-th:px-3 prose-th:py-2 prose-td:px-3 prose-td:py-2 break-words [overflow-wrap:anywhere]">
             <ReactMarkdown
               remarkPlugins={markdownRemarkPlugins}
               rehypePlugins={markdownRehypePlugins}

--- a/frontend/app/chat/[sessionId]/components/UserMessage.tsx
+++ b/frontend/app/chat/[sessionId]/components/UserMessage.tsx
@@ -1,6 +1,5 @@
 import { AudioLines, FileText } from 'lucide-react';
-import ReactMarkdown from 'react-markdown';
-import { markdownRemarkPlugins, markdownRehypePlugins, markdownComponents, preprocessMarkdown } from '../utils/markdown';
+import { CodeBlock, fencedCodeBlockPattern } from '../utils/markdown';
 import type { MessageFile } from '../types';
 
 const getFileBadge = (mimeType: string) => {
@@ -26,6 +25,36 @@ const getFileBadge = (mimeType: string) => {
     badgeClassName: 'bg-zinc-200 dark:bg-zinc-700',
   };
 };
+
+/**
+ * Renders user message content as plain text with fenced code block support.
+ * Plain text is rendered with `white-space: pre-wrap` to preserve spaces,
+ * indentation, and newlines exactly as typed. Fenced code blocks (```) are
+ * rendered with syntax highlighting via CodeBlock.
+ */
+function renderUserContent(content: string) {
+  const parts = content.split(fencedCodeBlockPattern);
+  return parts.map((part, i) => {
+    if (i % 2 === 1) {
+      // Fenced code block — extract language and code, render with CodeBlock
+      const match = part.match(/^```(\w*)\n?([\s\S]*?)```$/);
+      const language = match?.[1] || '';
+      const code = match?.[2]?.replace(/\n$/, '') || part;
+      return (
+        <CodeBlock key={i} className={language ? `language-${language}` : undefined}>
+          {code}
+        </CodeBlock>
+      );
+    }
+    // Plain text — preserve whitespace exactly as typed
+    if (!part) return null;
+    return (
+      <span key={i} className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+        {part}
+      </span>
+    );
+  });
+}
 
 interface UserMessageProps {
   content: string;
@@ -91,14 +120,8 @@ export function UserMessage({ content, images, fileNames, files }: UserMessagePr
         </div>
       )}
       {content && (
-        <div className="prose prose-sm prose-zinc dark:prose-invert max-w-none min-w-0 prose-p:my-3 prose-p:leading-relaxed prose-pre:p-0 prose-pre:rounded-lg prose-headings:my-4 prose-headings:font-semibold break-words break-all [overflow-wrap:anywhere]">
-          <ReactMarkdown
-            remarkPlugins={markdownRemarkPlugins}
-            rehypePlugins={markdownRehypePlugins}
-            components={markdownComponents}
-          >
-            {preprocessMarkdown(content)}
-          </ReactMarkdown>
+        <div className="text-sm leading-relaxed min-w-0 break-words [overflow-wrap:anywhere]">
+          {renderUserContent(content)}
         </div>
       )}
     </div>

--- a/frontend/app/chat/[sessionId]/utils/markdown.tsx
+++ b/frontend/app/chat/[sessionId]/utils/markdown.tsx
@@ -47,7 +47,7 @@ function isSvgCodeElement(element: React.ReactElement<CodeElementProps> | null):
 export const markdownRemarkPlugins: PluggableList = [remarkGfm, remarkBreaks, remarkMath];
 
 const currencyPattern = /(?<!\\)\$(\d+(?:,\d{3})*(?:\.\d+)?)(?=$|[\s),?!:;%\]]|\.(?!\d))/g;
-const fencedCodeBlockPattern = /(```[\s\S]*?```)/g;
+export const fencedCodeBlockPattern = /(```[\s\S]*?```)/g;
 const rawSvgPattern = /(?:<\?xml[\s\S]*?\?>\s*)?(?:<!DOCTYPE[\s\S]*?>\s*)?<svg\b[\s\S]*?<\/svg>/gi;
 
 function transformOutsideCodeFences(content: string, transform: (segment: string) => string): string {
@@ -70,7 +70,8 @@ function normalizeRawSvgBlocks(content: string): string {
  */
 export function preprocessMarkdown(content: string): string {
   return transformOutsideCodeFences(normalizeRawSvgBlocks(content), (segment) => (
-    segment.replace(currencyPattern, (_, amount: string) => `\\$${amount}`)
+    segment
+      .replace(currencyPattern, (_, amount: string) => `\\$${amount}`)
   ));
 }
 export const markdownRehypePlugins: PluggableList = [rehypeKatex];
@@ -84,7 +85,7 @@ const markdownTableStyles = {
 };
 
 // Code Block component with syntax highlighting and copy button
-const CodeBlock = ({ className, children }: { className?: string; children: React.ReactNode }) => {
+export const CodeBlock = ({ className, children }: { className?: string; children: React.ReactNode }) => {
   const language = getCodeLanguage(className);
   const [codeCopied, setCodeCopied] = useState(false);
   const codeString = String(children).replace(/\n$/, '');


### PR DESCRIPTION
## Summary
- Replace ReactMarkdown with plain text rendering for user messages, preserving whitespace while supporting fenced code blocks
- Fix horizontal overflow across chat layout by using `overflow-x-hidden` and `min-w-0` on flex containers
- Reduce AI message paragraph spacing and add horizontal scroll for code blocks

## Test plan
- [ ] Verify user messages with long text/code don't overflow horizontally
- [ ] Verify fenced code blocks in user messages render with syntax highlighting
- [ ] Verify AI message code blocks are horizontally scrollable