### PR TITLE
feat: add TTS button to user messages

### DIFF
--- a/frontend/app/chat/[sessionId]/components/ChatMessagesPane.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatMessagesPane.tsx
@@ -3,6 +3,7 @@ import { Check, Copy, Pencil } from 'lucide-react';
 import { Button } from '@/app/components/ui/button';
 import { cn } from '@/app/lib/utils';
 import { ChatSkeleton, AIMessageContent, UserMessage, UserAvatar } from './index';
+import { TTSButton } from './TTSButton';
 import type { AgentInfo, Message } from '../types';
 
 const isImeComposing = (event: React.KeyboardEvent<HTMLTextAreaElement>) =>
@@ -209,6 +210,9 @@ export const ChatMessagesPane = memo(function ChatMessagesPane({
                     </>
                   ) : (
                     <>
+                      {message.content && (
+                        <TTSButton text={message.content} messageId={message.id || 'unknown'} />
+                      )}
                       <Button
                         size="sm"
                         variant="ghost"


### PR DESCRIPTION
## Summary
- Add TTS (text-to-speech) playback button to user-sent messages
- Reuses the existing `TTSButton` component already used for assistant messages
- Button appears alongside the edit and copy buttons on hover

## Test plan
- [ ] Verify TTS button appears on user messages on hover
- [ ] Verify clicking the button plays back the user message text
- [ ] Verify stop functionality works during playback