### PR TITLE
feat: add real-time voice conversation via Gemini Live API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __debug_*
 *.png
 .claude/
 cmd/aiguide/data/
+*.log
 
 # Docker artifacts
 *.tar

--- a/cmd/aiguide/aiguide.yaml.example
+++ b/cmd/aiguide/aiguide.yaml.example
@@ -6,6 +6,10 @@ api_key: your_gemini_api_key_here
 model_name: gemini-2.0-flash-exp
 # base_url: https://xxxx.com # 自定义 Gemini API Base URL (可选)
 
+# Gemini Live API 模型（可选，用于实时语音对话）
+# 使用与主模型相同的 api_key 和 proxy
+# live_model: "gemini-3.1-flash-live-preview"
+
 # 服务器配置
 use_gin: true
 gin_port: 8080

--- a/cmd/aiguide/logger.go
+++ b/cmd/aiguide/logger.go
@@ -13,8 +13,19 @@ func initLogger() {
 	opts := &slog.HandlerOptions{
 		AddSource: true,
 	}
+
+	logFile, err := os.OpenFile("aiguide.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		logFile = nil
+	}
+
+	var dest io.Writer = os.Stdout
+	if logFile != nil {
+		dest = io.MultiWriter(os.Stdout, logFile)
+	}
+
 	// Use a custom writer to convert escaped "\n" back to real newlines
-	writer := &newlineWriter{w: os.Stdout}
+	writer := &newlineWriter{w: dest}
 	var handler slog.Handler = slog.NewTextHandler(writer, opts)
 	handler = &stackHandler{handler}
 	slog.SetDefault(slog.New(handler))

--- a/frontend/app/chat/ChatPageClient.tsx
+++ b/frontend/app/chat/ChatPageClient.tsx
@@ -13,7 +13,9 @@ import { useSessionData } from './[sessionId]/hooks/useSessionData';
 import { useStreamingChat } from './[sessionId]/hooks/useStreamingChat';
 import { useUIState } from './[sessionId]/hooks/useUIState';
 import { useVoiceInput } from './[sessionId]/hooks/useVoiceInput';
+import { useVoiceCall } from './[sessionId]/hooks/useVoiceCall';
 import { mergeAssistantMessages } from './[sessionId]/utils/messages';
+import { createSessionId, getChatPath } from './utils/session';
 
 export default function ChatPageClient() {
   const params = useParams();
@@ -128,6 +130,31 @@ export default function ChatPageClient() {
     disabled: isLoading,
   });
 
+  const {
+    status: voiceCallStatus,
+    voiceMessages,
+    startCall,
+    endCall,
+    error: voiceCallError,
+  } = useVoiceCall(sessionId);
+
+  const isVoiceCallActive = voiceCallStatus === 'connected' || voiceCallStatus === 'connecting';
+
+  const handleVoiceCallToggle = useCallback(() => {
+    if (isVoiceCallActive) {
+      endCall();
+    } else {
+      let targetSessionId = sessionId;
+      if (!targetSessionId) {
+        targetSessionId = createSessionId();
+        setSessionId(targetSessionId);
+        markSessionLoaded(targetSessionId);
+        window.history.pushState(null, '', getChatPath(targetSessionId));
+      }
+      startCall(targetSessionId);
+    }
+  }, [isVoiceCallActive, endCall, startCall, sessionId, setSessionId, markSessionLoaded]);
+
   const scroll = useScrollManager({
     messages,
     isStreamingResponse,
@@ -195,7 +222,24 @@ export default function ChatPageClient() {
     if (!agentInfo) router.push('/');
   }, [agentInfo, loading, router, user]);
 
-  const processedMessages = useMemo(() => mergeAssistantMessages(messages), [messages]);
+  const processedMessages = useMemo(() => {
+    const allMessages = [...messages];
+    if (voiceMessages.length > 0) {
+      const now = new Date();
+      for (const vm of voiceMessages) {
+        allMessages.push({
+          id: vm.id,
+          role: vm.role === 'user' ? 'user' : 'assistant',
+          content: vm.transcript,
+          timestamp: now,
+          isStreaming: !vm.isComplete,
+          voiceAudioUrl: vm.audioUrl ?? undefined,
+          isVoiceMessage: true,
+        });
+      }
+    }
+    return mergeAssistantMessages(allMessages);
+  }, [messages, voiceMessages]);
   const chatUser = useMemo(
     () => (user ? { name: user.name, picture: user.picture } : null),
     [user]
@@ -331,6 +375,11 @@ export default function ChatPageClient() {
       isVoiceSupported={isVoiceSupported}
       onVoiceToggle={toggleRecording}
       voiceError={voiceError}
+      isVoiceCallActive={isVoiceCallActive}
+      onVoiceCallToggle={handleVoiceCallToggle}
+      voiceCallStatus={voiceCallStatus}
+      voiceCallError={voiceCallError}
+      onEndVoiceCall={endCall}
       onCloseShareModal={ui.handleCloseShareModal}
       onCloseCreateProjectModal={ui.handleCloseCreateProjectModal}
       onSubmitCreateProject={handleCreateProject}

--- a/frontend/app/chat/[sessionId]/components/AudioWaveform.tsx
+++ b/frontend/app/chat/[sessionId]/components/AudioWaveform.tsx
@@ -1,0 +1,33 @@
+import { memo } from 'react';
+import { cn } from '@/app/lib/utils';
+
+interface AudioWaveformProps {
+  className?: string;
+}
+
+const BAR_COUNT = 28;
+
+const bars = Array.from({ length: BAR_COUNT }, (_, i) => {
+  const center = (BAR_COUNT - 1) / 2;
+  const dist = Math.abs(i - center) / center;
+  const maxScale = 1 - dist * 0.6;
+  return { index: i, maxScale };
+});
+
+export const AudioWaveform = memo(function AudioWaveform({ className }: AudioWaveformProps) {
+  return (
+    <div className={cn('flex items-center gap-[2px] h-6', className)}>
+      {bars.map(({ index, maxScale }) => (
+        <span
+          key={index}
+          className="inline-block w-[3px] rounded-full bg-current animate-waveform"
+          style={{
+            animationDelay: `${index * 60}ms`,
+            // @ts-expect-error CSS custom property
+            '--waveform-max-scale': maxScale,
+          }}
+        />
+      ))}
+    </div>
+  );
+});

--- a/frontend/app/chat/[sessionId]/components/ChatInput.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatInput.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, memo, useRef } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { Textarea } from '@/app/components/ui/textarea';
-import { ArrowUp, X, Paperclip, MessageSquare, FileText, AudioLines, Mic } from 'lucide-react';
+import { ArrowUp, X, Paperclip, MessageSquare, FileText, AudioLines, Mic, Phone } from 'lucide-react';
 import { cn } from '@/app/lib/utils';
 import type { SelectedImage } from '../types';
 
@@ -29,6 +29,8 @@ interface ChatInputProps {
   isVoiceSupported?: boolean;
   onVoiceToggle?: () => void;
   voiceError?: string | null;
+  isVoiceCallActive?: boolean;
+  onVoiceCallToggle?: () => void;
 }
 
 const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(({ 
@@ -55,6 +57,8 @@ const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(({
   isVoiceSupported = false,
   onVoiceToggle,
   voiceError,
+  isVoiceCallActive = false,
+  onVoiceCallToggle,
 }, textareaRef) => {
   const imageInputRef = useRef<HTMLInputElement>(null);
 
@@ -169,6 +173,26 @@ const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(({
                   <Mic className="h-4 w-4 sm:h-3.5 sm:w-3.5" />
                 </Button>
               </div>
+            )}
+            {onVoiceCallToggle && (
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                onClick={onVoiceCallToggle}
+                disabled={isLoading || isLoadingHistory}
+                className={cn(
+                  "h-8 w-8 sm:h-7 sm:w-7 rounded-full transition-all duration-200",
+                  isVoiceCallActive
+                    ? "bg-green-500 text-white hover:bg-green-600 shadow-md"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+                title={isVoiceCallActive ? "结束语音通话" : "语音通话"}
+                aria-label={isVoiceCallActive ? "结束语音通话" : "语音通话"}
+                aria-pressed={isVoiceCallActive}
+              >
+                <Phone className="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+              </Button>
             )}
             <Textarea
               ref={textareaRef}

--- a/frontend/app/chat/[sessionId]/components/ChatMessagesPane.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatMessagesPane.tsx
@@ -3,6 +3,8 @@ import { Check, Copy, Pencil } from 'lucide-react';
 import { Button } from '@/app/components/ui/button';
 import { cn } from '@/app/lib/utils';
 import { ChatSkeleton, AIMessageContent, UserMessage, UserAvatar } from './index';
+import { AudioWaveform } from './AudioWaveform';
+import { VoiceAudioPlayer, resolveVoiceAudioUrl } from './VoiceAudioPlayer';
 import { TTSButton } from './TTSButton';
 import type { AgentInfo, Message } from '../types';
 
@@ -70,7 +72,7 @@ export const ChatMessagesPane = memo(function ChatMessagesPane({
     );
   }
 
-  if (messages.length === 0) {
+  if (messages.length === 0 && processedMessages.length === 0) {
     return (
       <div className="text-center animate-fade-in px-4 pb-2">
         <div className="flex justify-center mb-5 sm:mb-6">
@@ -121,6 +123,14 @@ export const ChatMessagesPane = memo(function ChatMessagesPane({
           >
           {message.role === 'assistant' ? (
             <div className="w-full">
+              {message.isVoiceMessage && message.isStreaming ? (
+                <AudioWaveform className="text-zinc-400 dark:text-zinc-500 mb-2" />
+              ) : resolveVoiceAudioUrl(message.voiceAudioFileId, message.voiceAudioUrl) ? (
+                <VoiceAudioPlayer
+                  audioUrl={resolveVoiceAudioUrl(message.voiceAudioFileId, message.voiceAudioUrl)!}
+                  className="max-w-sm mb-2"
+                />
+              ) : null}
               <div className="relative text-sm w-full leading-relaxed" data-ai-message="">
                 <AIMessageContent
                   id={message.id}
@@ -174,6 +184,8 @@ export const ChatMessagesPane = memo(function ChatMessagesPane({
                       images={message.images}
                       fileNames={message.fileNames}
                       files={message.files}
+                      voiceAudioFileId={message.voiceAudioFileId}
+                      voiceAudioUrl={message.voiceAudioUrl}
                     />
                   )}
                 </div>

--- a/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
@@ -1,5 +1,5 @@
 import { type Ref, type RefObject } from 'react';
-import { Menu } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
 import SessionSidebar from '@/app/components/SessionSidebar';
 import { Button } from '@/app/components/ui/button';
 import { ChatInput, CreateProjectModal, SelectionAskTooltip } from './index';
@@ -7,6 +7,7 @@ import { ChatMessagesPane } from './ChatMessagesPane';
 import { ShareModal } from './ShareModal';
 import { COMPOSER_MESSAGE_GAP } from '../constants';
 import type { AgentInfo, Message, SelectedImage } from '../types';
+import type { VoiceCallStatus } from '../hooks/useVoiceCall';
 import type { Session, Project } from '@/app/components/SessionSidebar';
 
 interface ChatPageLayoutProps {
@@ -101,6 +102,13 @@ interface ChatPageLayoutProps {
   onVoiceToggle?: () => void;
   voiceError?: string | null;
 
+  // Voice call
+  isVoiceCallActive?: boolean;
+  onVoiceCallToggle?: () => void;
+  voiceCallStatus?: VoiceCallStatus;
+  voiceCallError?: string | null;
+  onEndVoiceCall?: () => void;
+
   // Handlers – modals
   onCloseShareModal: () => void;
   onCloseCreateProjectModal: () => void;
@@ -183,6 +191,11 @@ export function ChatPageLayout({
   isVoiceSupported,
   onVoiceToggle,
   voiceError,
+  isVoiceCallActive,
+  onVoiceCallToggle,
+  voiceCallStatus,
+  voiceCallError,
+  onEndVoiceCall,
   onCloseShareModal,
   onCloseCreateProjectModal,
   onSubmitCreateProject,
@@ -190,7 +203,7 @@ export function ChatPageLayout({
   onSubmitRenameProject,
   onScroll,
 }: ChatPageLayoutProps) {
-  const isEmptyState = messages.length === 0 && !isLoadingHistory;
+  const isEmptyState = messages.length === 0 && processedMessages.length === 0 && !isLoadingHistory && !isVoiceCallActive;
 
   const messagesPaneProps = {
     agentInfo,
@@ -243,6 +256,8 @@ export function ChatPageLayout({
     isVoiceSupported,
     onVoiceToggle,
     voiceError,
+    isVoiceCallActive,
+    onVoiceCallToggle,
   };
 
   return (
@@ -306,6 +321,28 @@ export function ChatPageLayout({
                 </div>
               </div>
             </div>
+            {(voiceCallStatus === 'connected' || voiceCallError) && (
+              <div className="w-full md:pl-[260px] flex justify-center px-3 sm:px-4 md:px-6">
+                {voiceCallStatus === 'connected' ? (
+                  <div className="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+                    <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
+                    <span>Stream is live</span>
+                    {onEndVoiceCall && (
+                      <button
+                        type="button"
+                        onClick={onEndVoiceCall}
+                        className="ml-1 p-0.5 rounded hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors"
+                        aria-label="End voice call"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
+                ) : (
+                  <span className="text-xs text-red-500">{voiceCallError}</span>
+                )}
+              </div>
+            )}
             <ChatInput {...chatInputProps} />
           </>
         )}

--- a/frontend/app/chat/[sessionId]/components/UserMessage.tsx
+++ b/frontend/app/chat/[sessionId]/components/UserMessage.tsx
@@ -1,5 +1,6 @@
 import { AudioLines, FileText } from 'lucide-react';
 import { CodeBlock, fencedCodeBlockPattern } from '../utils/markdown';
+import { VoiceAudioPlayer, resolveVoiceAudioUrl } from './VoiceAudioPlayer';
 import type { MessageFile } from '../types';
 
 const getFileBadge = (mimeType: string) => {
@@ -61,11 +62,19 @@ interface UserMessageProps {
   images?: string[];
   fileNames?: string[];
   files?: MessageFile[];
+  voiceAudioFileId?: number;
+  voiceAudioUrl?: string;
 }
 
-export function UserMessage({ content, images, fileNames, files }: UserMessageProps) {
+export function UserMessage({ content, images, fileNames, files, voiceAudioFileId, voiceAudioUrl }: UserMessageProps) {
   return (
     <div className="space-y-2">
+      {resolveVoiceAudioUrl(voiceAudioFileId, voiceAudioUrl) && (
+        <VoiceAudioPlayer
+          audioUrl={resolveVoiceAudioUrl(voiceAudioFileId, voiceAudioUrl)!}
+          className="max-w-sm"
+        />
+      )}
       {files && files.length > 0 && (
         <div className="space-y-2">
           {files.map((file, index) => {

--- a/frontend/app/chat/[sessionId]/components/VoiceAudioPlayer.tsx
+++ b/frontend/app/chat/[sessionId]/components/VoiceAudioPlayer.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { Play, Pause, Volume2 } from 'lucide-react';
+import { cn } from '@/app/lib/utils';
+
+export function resolveVoiceAudioUrl(fileId?: number, blobUrl?: string): string | undefined {
+  if (blobUrl) return blobUrl;
+  if (fileId) return `/api/assistant/files/${fileId}/download`;
+  return undefined;
+}
+
+interface VoiceAudioPlayerProps {
+  audioUrl: string;
+  className?: string;
+}
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export const VoiceAudioPlayer = memo(function VoiceAudioPlayer({
+  audioUrl,
+  className,
+}: VoiceAudioPlayerProps) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+
+  useEffect(() => {
+    const audio = new Audio(audioUrl);
+    audioRef.current = audio;
+
+    const onLoadedMetadata = () => setDuration(audio.duration);
+    const onTimeUpdate = () => setCurrentTime(audio.currentTime);
+    const onEnded = () => { setIsPlaying(false); setCurrentTime(0); };
+
+    audio.addEventListener('loadedmetadata', onLoadedMetadata);
+    audio.addEventListener('timeupdate', onTimeUpdate);
+    audio.addEventListener('ended', onEnded);
+
+    return () => {
+      audio.removeEventListener('loadedmetadata', onLoadedMetadata);
+      audio.removeEventListener('timeupdate', onTimeUpdate);
+      audio.removeEventListener('ended', onEnded);
+      audio.pause();
+      audio.src = '';
+    };
+  }, [audioUrl]);
+
+  const togglePlay = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (isPlaying) {
+      audio.pause();
+      setIsPlaying(false);
+    } else {
+      audio.play();
+      setIsPlaying(true);
+    }
+  }, [isPlaying]);
+
+  const handleSeek = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const time = parseFloat(e.target.value);
+    audio.currentTime = time;
+    setCurrentTime(time);
+  }, []);
+
+  const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
+
+  return (
+    <div className={cn(
+      "flex items-center gap-2.5 rounded-full bg-zinc-100 dark:bg-zinc-800 pl-1 pr-3 py-1",
+      className,
+    )}>
+      <button
+        type="button"
+        onClick={togglePlay}
+        className="flex items-center justify-center h-8 w-8 rounded-full bg-white dark:bg-zinc-700 shadow-sm hover:shadow transition-shadow"
+        aria-label={isPlaying ? "Pause" : "Play"}
+      >
+        {isPlaying ? (
+          <Pause className="h-3.5 w-3.5 text-zinc-700 dark:text-zinc-200" />
+        ) : (
+          <Play className="h-3.5 w-3.5 text-zinc-700 dark:text-zinc-200 ml-0.5" />
+        )}
+      </button>
+
+      <span className="text-xs text-zinc-500 dark:text-zinc-400 tabular-nums min-w-[72px]">
+        {formatTime(currentTime)} / {formatTime(duration)}
+      </span>
+
+      <div className="relative flex-1 min-w-[80px]">
+        <div className="h-1 rounded-full bg-zinc-300 dark:bg-zinc-600">
+          <div
+            className="h-1 rounded-full bg-zinc-500 dark:bg-zinc-400 transition-all duration-100"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={duration || 0}
+          step={0.1}
+          value={currentTime}
+          onChange={handleSeek}
+          className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+          aria-label="Seek"
+        />
+      </div>
+
+      <Volume2 className="h-3.5 w-3.5 text-zinc-400 dark:text-zinc-500 flex-shrink-0" />
+    </div>
+  );
+});

--- a/frontend/app/chat/[sessionId]/hooks/useVoiceCall.ts
+++ b/frontend/app/chat/[sessionId]/hooks/useVoiceCall.ts
@@ -1,0 +1,441 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type VoiceCallStatus = 'idle' | 'connecting' | 'connected' | 'error';
+
+export interface VoiceMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  audioUrl: string | null;
+  transcript: string;
+  isComplete: boolean;
+}
+
+interface UseVoiceCallResult {
+  status: VoiceCallStatus;
+  voiceMessages: VoiceMessage[];
+  startCall: (overrideSessionId?: string) => Promise<void>;
+  endCall: () => void;
+  error: string | null;
+}
+
+const INPUT_SAMPLE_RATE = 16000;
+const OUTPUT_SAMPLE_RATE = 24000;
+
+let nextMsgId = 0;
+function genId(): string {
+  return `vm-${Date.now()}-${nextMsgId++}`;
+}
+
+function getBackendWsUrl(): string {
+  if (process.env.NEXT_PUBLIC_BACKEND_WS_URL) {
+    return process.env.NEXT_PUBLIC_BACKEND_WS_URL;
+  }
+  if (typeof window !== 'undefined') {
+    const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    return `${proto}://${window.location.hostname}:8080`;
+  }
+  return 'ws://localhost:8080';
+}
+
+function pcmToWavBlob(int16Chunks: Int16Array[], sampleRate: number): Blob {
+  let totalLen = 0;
+  for (const chunk of int16Chunks) totalLen += chunk.length;
+
+  const pcm = new Int16Array(totalLen);
+  let offset = 0;
+  for (const chunk of int16Chunks) {
+    pcm.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  const buffer = new ArrayBuffer(44 + pcm.length * 2);
+  const view = new DataView(buffer);
+  const numChannels = 1;
+  const bitsPerSample = 16;
+  const byteRate = sampleRate * numChannels * (bitsPerSample / 8);
+  const blockAlign = numChannels * (bitsPerSample / 8);
+  const dataSize = pcm.length * 2;
+
+  writeString(view, 0, 'RIFF');
+  view.setUint32(4, 36 + dataSize, true);
+  writeString(view, 8, 'WAVE');
+  writeString(view, 12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bitsPerSample, true);
+  writeString(view, 36, 'data');
+  view.setUint32(40, dataSize, true);
+
+  const pcmBytes = new Uint8Array(pcm.buffer);
+  new Uint8Array(buffer).set(pcmBytes, 44);
+
+  return new Blob([buffer], { type: 'audio/wav' });
+}
+
+function writeString(view: DataView, offset: number, str: string) {
+  for (let i = 0; i < str.length; i++) {
+    view.setUint8(offset + i, str.charCodeAt(i));
+  }
+}
+
+function base64ToPcmInt16(b64: string): Int16Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new Int16Array(bytes.buffer);
+}
+
+interface TurnRefs {
+  turnPhase: React.MutableRefObject<'waiting' | 'user' | 'model'>;
+  userAudioChunks: React.MutableRefObject<Int16Array[]>;
+  modelAudioChunks: React.MutableRefObject<Int16Array[]>;
+  currentUserMsgId: React.MutableRefObject<string | null>;
+  currentModelMsgId: React.MutableRefObject<string | null>;
+}
+
+export function useVoiceCall(sessionId?: string): UseVoiceCallResult {
+  const [status, setStatus] = useState<VoiceCallStatus>('idle');
+  const [voiceMessages, setVoiceMessages] = useState<VoiceMessage[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const prevSessionIdRef = useRef(sessionId);
+  useEffect(() => {
+    if (prevSessionIdRef.current !== sessionId) {
+      prevSessionIdRef.current = sessionId;
+      setVoiceMessages([]);
+    }
+  }, [sessionId]);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const sourceNodeRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const processorRef = useRef<ScriptProcessorNode | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  const playbackCtxRef = useRef<AudioContext | null>(null);
+  const nextPlayTimeRef = useRef(0);
+
+  const turnPhaseRef = useRef<'waiting' | 'user' | 'model'>('waiting');
+  const userAudioChunksRef = useRef<Int16Array[]>([]);
+  const modelAudioChunksRef = useRef<Int16Array[]>([]);
+  const currentUserMsgIdRef = useRef<string | null>(null);
+  const currentModelMsgIdRef = useRef<string | null>(null);
+
+  const turnRefs: TurnRefs = {
+    turnPhase: turnPhaseRef,
+    userAudioChunks: userAudioChunksRef,
+    modelAudioChunks: modelAudioChunksRef,
+    currentUserMsgId: currentUserMsgIdRef,
+    currentModelMsgId: currentModelMsgIdRef,
+  };
+
+  const cleanup = useCallback(() => {
+    processorRef.current?.disconnect();
+    processorRef.current = null;
+    sourceNodeRef.current?.disconnect();
+    sourceNodeRef.current = null;
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+    audioCtxRef.current?.close();
+    audioCtxRef.current = null;
+
+    if (wsRef.current) {
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+
+    playbackCtxRef.current?.close();
+    playbackCtxRef.current = null;
+    nextPlayTimeRef.current = 0;
+
+    turnPhaseRef.current = 'waiting';
+    userAudioChunksRef.current = [];
+    modelAudioChunksRef.current = [];
+    currentUserMsgIdRef.current = null;
+    currentModelMsgIdRef.current = null;
+
+    setStatus('idle');
+  }, []);
+
+  useEffect(() => () => cleanup(), [cleanup]);
+
+  const finalizeTurn = useCallback((
+    msgIdRef: React.MutableRefObject<string | null>,
+    chunksRef: React.MutableRefObject<Int16Array[]>,
+    sampleRate: number,
+  ) => {
+    const msgId = msgIdRef.current;
+    const chunks = chunksRef.current;
+    if (msgId) {
+      if (chunks.length > 0) {
+        const blob = pcmToWavBlob(chunks, sampleRate);
+        const url = URL.createObjectURL(blob);
+        setVoiceMessages((prev) =>
+          prev.map((m) => (m.id === msgId ? { ...m, audioUrl: url, isComplete: true } : m))
+        );
+      } else {
+        setVoiceMessages((prev) =>
+          prev.map((m) => (m.id === msgId ? { ...m, isComplete: true } : m))
+        );
+      }
+    }
+    chunksRef.current = [];
+    msgIdRef.current = null;
+  }, []);
+
+  const finalizeUserTurn = useCallback(() => {
+    finalizeTurn(currentUserMsgIdRef, userAudioChunksRef, INPUT_SAMPLE_RATE);
+  }, [finalizeTurn]);
+
+  const finalizeModelTurn = useCallback(() => {
+    finalizeTurn(currentModelMsgIdRef, modelAudioChunksRef, OUTPUT_SAMPLE_RATE);
+  }, [finalizeTurn]);
+
+  const playPCMChunk = useCallback((pcmData: Int16Array) => {
+    if (!playbackCtxRef.current) {
+      playbackCtxRef.current = new AudioContext({ sampleRate: OUTPUT_SAMPLE_RATE });
+      nextPlayTimeRef.current = playbackCtxRef.current.currentTime;
+    }
+    const ctx = playbackCtxRef.current;
+
+    const float32 = new Float32Array(pcmData.length);
+    for (let i = 0; i < pcmData.length; i++) {
+      float32[i] = pcmData[i] / 32768.0;
+    }
+
+    const audioBuffer = ctx.createBuffer(1, float32.length, OUTPUT_SAMPLE_RATE);
+    audioBuffer.copyToChannel(float32, 0);
+
+    const source = ctx.createBufferSource();
+    source.buffer = audioBuffer;
+    source.connect(ctx.destination);
+
+    const startTime = Math.max(nextPlayTimeRef.current, ctx.currentTime);
+    source.start(startTime);
+    nextPlayTimeRef.current = startTime + audioBuffer.duration;
+  }, []);
+
+  const resetPlayback = useCallback(() => {
+    playbackCtxRef.current?.close();
+    playbackCtxRef.current = null;
+    nextPlayTimeRef.current = 0;
+  }, []);
+
+  const startCapture = useCallback((stream: MediaStream, ws: WebSocket) => {
+    const audioCtx = new AudioContext({ sampleRate: INPUT_SAMPLE_RATE });
+    audioCtxRef.current = audioCtx;
+
+    const source = audioCtx.createMediaStreamSource(stream);
+    sourceNodeRef.current = source;
+
+    const processor = audioCtx.createScriptProcessor(4096, 1, 1);
+    processorRef.current = processor;
+
+    processor.onaudioprocess = (e) => {
+      if (ws.readyState !== WebSocket.OPEN) return;
+
+      const float32 = e.inputBuffer.getChannelData(0);
+      const int16 = new Int16Array(float32.length);
+      for (let i = 0; i < float32.length; i++) {
+        const s = Math.max(-1, Math.min(1, float32[i]));
+        int16[i] = s < 0 ? s * 32768 : s * 32767;
+      }
+
+      userAudioChunksRef.current.push(int16.slice());
+
+      const bytes = new Uint8Array(int16.buffer);
+      const chars = new Array<string>(bytes.length);
+      for (let i = 0; i < bytes.length; i++) chars[i] = String.fromCharCode(bytes[i]);
+      ws.send(JSON.stringify({ type: 'audio', data: btoa(chars.join('')) }));
+    };
+
+    source.connect(processor);
+    processor.connect(audioCtx.destination);
+  }, []);
+
+  const handleWsMessage = useCallback((event: MessageEvent, stream: MediaStream, ws: WebSocket) => {
+    let msg: { type: string; data?: string; finished?: boolean };
+    try {
+      msg = JSON.parse(event.data as string);
+    } catch {
+      return;
+    }
+
+    switch (msg.type) {
+      case 'setup_ok':
+        setStatus('connected');
+        startCapture(stream, ws);
+        break;
+
+      case 'input_transcript':
+        if (turnPhaseRef.current === 'model') {
+          finalizeModelTurn();
+        }
+        handleInputTranscript(msg.data, turnRefs, setVoiceMessages);
+        break;
+
+      case 'audio':
+        if (turnPhaseRef.current === 'user') {
+          finalizeUserTurn();
+        }
+        handleAudioMessage(msg.data, turnRefs, setVoiceMessages, playPCMChunk);
+        break;
+
+      case 'output_transcript':
+        handleOutputTranscript(msg.data, turnRefs, setVoiceMessages);
+        break;
+
+      case 'turn_complete':
+        finalizeModelTurn();
+        turnPhaseRef.current = 'waiting';
+        userAudioChunksRef.current = [];
+        break;
+
+      case 'interrupted':
+        resetPlayback();
+        finalizeModelTurn();
+        turnPhaseRef.current = 'waiting';
+        userAudioChunksRef.current = [];
+        break;
+
+      case 'go_away':
+        cleanup();
+        break;
+
+      case 'error':
+        setError(msg.data ?? 'Voice call error');
+        setStatus('error');
+        cleanup();
+        break;
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cleanup, finalizeModelTurn, finalizeUserTurn, playPCMChunk, resetPlayback, startCapture]);
+
+  const startCall = useCallback(async (overrideSessionId?: string) => {
+    if (status !== 'idle') return;
+    setError(null);
+    setVoiceMessages([]);
+    setStatus('connecting');
+
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          sampleRate: INPUT_SAMPLE_RATE,
+          echoCancellation: true,
+          noiseSuppression: true,
+        },
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Microphone access denied';
+      setError(msg);
+      setStatus('error');
+      return;
+    }
+    streamRef.current = stream;
+
+    const resolvedSessionId = overrideSessionId || sessionId;
+    const wsUrl = `${getBackendWsUrl()}/api/assistant/live${resolvedSessionId ? `?session_id=${encodeURIComponent(resolvedSessionId)}` : ''}`;
+    const ws = new WebSocket(wsUrl);
+    wsRef.current = ws;
+
+    ws.onmessage = (ev) => handleWsMessage(ev, stream, ws);
+
+    ws.onerror = () => {
+      setError('WebSocket connection error');
+      setStatus('error');
+      cleanup();
+    };
+
+    ws.onclose = () => {
+      cleanup();
+    };
+  }, [cleanup, handleWsMessage, sessionId, status]);
+
+  const endCall = useCallback(() => {
+    if (userAudioChunksRef.current.length > 0 || currentUserMsgIdRef.current) {
+      finalizeUserTurn();
+    }
+    if (turnPhaseRef.current === 'model') finalizeModelTurn();
+
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ type: 'end' }));
+    }
+    cleanup();
+  }, [cleanup, finalizeModelTurn, finalizeUserTurn]);
+
+  return { status, voiceMessages, startCall, endCall, error };
+}
+
+function handleInputTranscript(
+  data: string | undefined,
+  refs: TurnRefs,
+  setMessages: React.Dispatch<React.SetStateAction<VoiceMessage[]>>,
+) {
+  if (!data) return;
+  if (refs.turnPhase.current !== 'user') {
+    refs.turnPhase.current = 'user';
+    const id = genId();
+    refs.currentUserMsgId.current = id;
+    setMessages((prev) => [
+      ...prev,
+      { id, role: 'user', audioUrl: null, transcript: '', isComplete: false },
+    ]);
+  }
+  const userMsgId = refs.currentUserMsgId.current;
+  if (userMsgId) {
+    setMessages((prev) =>
+      prev.map((m) =>
+        m.id === userMsgId ? { ...m, transcript: m.transcript + data } : m
+      )
+    );
+  }
+}
+
+function handleAudioMessage(
+  data: string | undefined,
+  refs: TurnRefs,
+  setMessages: React.Dispatch<React.SetStateAction<VoiceMessage[]>>,
+  playPCMChunk: (pcm: Int16Array) => void,
+) {
+  if (!data) return;
+  if (refs.turnPhase.current !== 'model') {
+    refs.turnPhase.current = 'model';
+    const id = genId();
+    refs.currentModelMsgId.current = id;
+    refs.modelAudioChunks.current = [];
+    setMessages((prev) => [
+      ...prev,
+      { id, role: 'assistant', audioUrl: null, transcript: '', isComplete: false },
+    ]);
+  }
+  const pcm = base64ToPcmInt16(data);
+  refs.modelAudioChunks.current.push(pcm);
+  playPCMChunk(pcm);
+}
+
+function handleOutputTranscript(
+  data: string | undefined,
+  refs: TurnRefs,
+  setMessages: React.Dispatch<React.SetStateAction<VoiceMessage[]>>,
+) {
+  if (!data) return;
+  const modelMsgId = refs.currentModelMsgId.current;
+  if (modelMsgId) {
+    setMessages((prev) =>
+      prev.map((m) =>
+        m.id === modelMsgId ? { ...m, transcript: m.transcript + data } : m
+      )
+    );
+  }
+}

--- a/frontend/app/chat/[sessionId]/types.ts
+++ b/frontend/app/chat/[sessionId]/types.ts
@@ -25,10 +25,13 @@ export interface Message {
   isStreaming?: boolean;
   images?: string[];
   videos?: string[];
-  fileNames?: string[]; // 文件名列表，与 images 对应
+  fileNames?: string[];
   files?: MessageFile[];
   isError?: boolean;
   toolCalls?: ToolCallItem[];
+  voiceAudioFileId?: number;
+  voiceAudioUrl?: string;
+  isVoiceMessage?: boolean;
 }
 
 export interface MessageFile {
@@ -73,6 +76,7 @@ export interface HistoryMessageResponse {
   file_names?: string[];
   files?: MessageFile[];
   tool_calls?: ToolCallResponse[];
+  voice_audio_file_id?: number;
 }
 
 export interface SessionHistoryResponse {

--- a/frontend/app/chat/[sessionId]/utils/messages.ts
+++ b/frontend/app/chat/[sessionId]/utils/messages.ts
@@ -51,6 +51,7 @@ export const mapHistoryMessage = (message: HistoryMessageResponse): Message => (
   fileNames: message.file_names || [],
   files: message.files || [],
   toolCalls: (message.tool_calls || []).map(mapToolCall),
+  voiceAudioFileId: message.voice_audio_file_id || undefined,
 });
 
 export const mergeAssistantMessages = (messages: Message[]) => {

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -198,4 +198,14 @@
   .bg-grid-black {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='32' height='32' fill='none' stroke='rgb(0 0 0 / 0.04)'%3E%3Cpath d='M0 .5H31.5V32'/%3E%3C/svg%3E");
   }
+
+  /* Voice waveform bar animation */
+  .animate-waveform {
+    animation: waveform 1.2s ease-in-out infinite alternate;
+  }
+
+  @keyframes waveform {
+    0% { height: 4px; }
+    100% { height: calc(var(--waveform-max-scale, 1) * 20px); }
+  }
 }

--- a/internal/app/aiguide/aiguide.go
+++ b/internal/app/aiguide/aiguide.go
@@ -45,6 +45,7 @@ type Config struct {
 	ExaSearch           ExaSearch    `yaml:"exa_search"` // Exa 搜索配置
 	Redis               redis.Config `yaml:"redis"`      // Redis 配置
 	RateLimit           RateLimit    `yaml:"rate_limit"` // 限流配置
+	LiveModel           string       `yaml:"live_model"`
 	FileStorageDir      string       `yaml:"file_storage_dir"`
 	PDFWorkDir          string       `yaml:"pdf_work_dir"`
 }
@@ -151,6 +152,10 @@ func New(ctx context.Context, config *Config) (*AIGuide, error) {
 		FrontendURL:         config.FrontendURL,
 		WebSearchConfig:     webSearchConfig,
 		ExaConfig:           tools.ExaConfig{APIKey: config.ExaSearch.APIKey},
+		APIKey:              config.APIKey,
+		BaseURL:             config.BaseURL,
+		HTTPClient:          httpClient,
+		LiveModel:           config.LiveModel,
 	}
 
 	fileStorageDir := config.FileStorageDir

--- a/internal/app/aiguide/assistant/assistant.go
+++ b/internal/app/aiguide/assistant/assistant.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"sync"
 
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/runner"
@@ -36,6 +38,14 @@ type Assistant struct {
 	scheduler      *Scheduler
 
 	authService *auth.AuthService
+
+	liveClient     *genai.Client
+	liveClientOnce sync.Once
+	liveClientErr  error
+	liveModel      string
+	apiKey         string
+	baseURL        string
+	httpClient     *http.Client
 }
 
 type Config struct {
@@ -49,6 +59,10 @@ type Config struct {
 	ExaConfig           tools.ExaConfig
 	FileStore           storage.FileStore
 	PDFWorkDir          string
+	APIKey              string
+	BaseURL             string
+	HTTPClient          *http.Client
+	LiveModel           string
 }
 
 func New(config *Config) (*Assistant, error) {
@@ -89,6 +103,10 @@ func New(config *Config) (*Assistant, error) {
 		exaConfig:           config.ExaConfig,
 		fileStore:           config.FileStore,
 		pdfWorkDir:          config.PDFWorkDir,
+		liveModel:           config.LiveModel,
+		apiKey:              config.APIKey,
+		baseURL:             config.BaseURL,
+		httpClient:          config.HTTPClient,
 	}
 
 	runner, err := assistant.createRunner()
@@ -110,4 +128,11 @@ func New(config *Config) (*Assistant, error) {
 func (a *Assistant) Run(ctx context.Context) error {
 	a.scheduler.Start(ctx)
 	return nil
+}
+
+func (a *Assistant) getLiveClient(ctx context.Context) (*genai.Client, error) {
+	a.liveClientOnce.Do(func() {
+		a.liveClient, a.liveClientErr = newLiveClient(ctx, a.apiKey, a.baseURL, a.httpClient)
+	})
+	return a.liveClient, a.liveClientErr
 }

--- a/internal/app/aiguide/assistant/live_api.go
+++ b/internal/app/aiguide/assistant/live_api.go
@@ -1,0 +1,499 @@
+package assistant
+
+import (
+	"aiguide/internal/pkg/constant"
+	"aiguide/internal/pkg/tools"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	adkmodel "google.golang.org/adk/model"
+	adksession "google.golang.org/adk/session"
+	"google.golang.org/genai"
+)
+
+const defaultLiveModel = "gemini-3.1-flash-live-preview"
+
+const (
+	phaseWaiting = "waiting"
+	phaseUser    = "user"
+	phaseModel   = "model"
+)
+
+var wsUpgrader = websocket.Upgrader{
+	ReadBufferSize:  4096,
+	WriteBufferSize: 4096,
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+type turnTracker struct {
+	phase      string
+	userAudio  [][]byte
+	userText   string
+	modelAudio [][]byte
+	modelText  string
+
+	mu           sync.Mutex
+	pendingAudio [][]byte
+	pendingText  string
+	pendingTimer *time.Timer
+}
+
+func (a *Assistant) VoiceCall(ctx *gin.Context) {
+	userID, ok := getContextUserID(ctx)
+	if !ok || userID <= 0 {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	sessionID := ctx.Query("session_id")
+	if sessionID == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "session_id is required"})
+		return
+	}
+
+	conn, err := wsUpgrader.Upgrade(ctx.Writer, ctx.Request, nil)
+	if err != nil {
+		slog.Error("VoiceCall: WebSocket upgrade failed", "err", err, "userID", userID)
+		return
+	}
+	defer conn.Close()
+
+	slog.Info("VoiceCall: WebSocket connected", "userID", userID, "sessionID", sessionID)
+
+	userIDStr := strconv.Itoa(userID)
+	if _, err := a.ensureSession(ctx, userIDStr, sessionID); err != nil {
+		slog.Error("VoiceCall: ensureSession failed", "err", err)
+		writeWSError(conn, "failed to ensure session: "+err.Error())
+		return
+	}
+
+	connCtx, connCancel := context.WithCancel(ctx.Request.Context())
+	defer connCancel()
+
+	liveSession, err := a.connectLiveSession(connCtx, userID)
+	if err != nil {
+		writeWSError(conn, err.Error())
+		return
+	}
+	defer liveSession.Close()
+
+	writeCh := make(chan wsServerMessage, 32)
+	defer close(writeCh)
+	go wsWriter(conn, writeCh, connCancel)
+
+	writeCh <- wsServerMessage{Type: serverMsgTypeSetupOK}
+
+	saveTurn, waitSaves := a.startSaveLoop(userID, sessionID)
+	defer waitSaves()
+
+	firstErr := a.bridgeVoiceCall(connCtx, connCancel, writeCh, liveSession, conn, saveTurn)
+
+	if firstErr != nil {
+		slog.Info("VoiceCall: session ended", "reason", firstErr.Error(), "userID", userID)
+	} else {
+		slog.Info("VoiceCall: session ended normally", "userID", userID)
+	}
+}
+
+func (a *Assistant) connectLiveSession(ctx context.Context, userID int) (*genai.Session, error) {
+	liveClient, err := a.getLiveClient(ctx)
+	if err != nil {
+		slog.Error("VoiceCall: getLiveClient failed", "err", err, "userID", userID)
+		return nil, fmt.Errorf("failed to initialize live client: %w", err)
+	}
+
+	liveModel := a.liveModel
+	if liveModel == "" {
+		liveModel = defaultLiveModel
+	}
+
+	session, err := liveClient.Live.Connect(ctx, liveModel, &genai.LiveConnectConfig{
+		ResponseModalities: []genai.Modality{genai.ModalityAudio},
+		SpeechConfig: &genai.SpeechConfig{
+			VoiceConfig: &genai.VoiceConfig{
+				PrebuiltVoiceConfig: &genai.PrebuiltVoiceConfig{
+					VoiceName: "Kore",
+				},
+			},
+		},
+		InputAudioTranscription:  &genai.AudioTranscriptionConfig{},
+		OutputAudioTranscription: &genai.AudioTranscriptionConfig{},
+	})
+	if err != nil {
+		slog.Error("VoiceCall: Live.Connect failed", "err", err, "userID", userID)
+		return nil, fmt.Errorf("failed to connect to Gemini Live: %w", err)
+	}
+	return session, nil
+}
+
+func wsWriter(conn *websocket.Conn, writeCh <-chan wsServerMessage, cancel context.CancelFunc) {
+	for msg := range writeCh {
+		data, err := json.Marshal(msg)
+		if err != nil {
+			slog.Error("VoiceCall: json.Marshal error", "err", err)
+			cancel()
+			return
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+			cancel()
+			return
+		}
+	}
+}
+
+type saveRequest struct {
+	role       string
+	text       string
+	audio      [][]byte
+	sampleRate uint32
+}
+
+func (a *Assistant) startSaveLoop(userID int, sessionID string) (saveTurn func(string, string, [][]byte, uint32), wait func()) {
+	saveCh := make(chan saveRequest, 16)
+	saveDone := make(chan struct{})
+	go func() {
+		defer close(saveDone)
+		for req := range saveCh {
+			a.saveVoiceTurn(context.Background(), userID, sessionID, req.role, req.text, req.audio, req.sampleRate)
+		}
+	}()
+
+	saveTurn = func(role, text string, audioChunks [][]byte, sampleRate uint32) {
+		slog.Info("saveTurn: queued", "role", role, "textLen", len(text), "audioChunks", len(audioChunks))
+		copied := make([][]byte, len(audioChunks))
+		copy(copied, audioChunks)
+		saveCh <- saveRequest{role: role, text: text, audio: copied, sampleRate: sampleRate}
+	}
+
+	wait = func() {
+		close(saveCh)
+		<-saveDone
+	}
+	return
+}
+
+func (a *Assistant) bridgeVoiceCall(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	writeCh chan<- wsServerMessage,
+	liveSession *genai.Session,
+	conn *websocket.Conn,
+	saveTurn func(string, string, [][]byte, uint32),
+) error {
+	tracker := &turnTracker{phase: phaseWaiting}
+
+	errCh := make(chan error, 2)
+	go func() {
+		errCh <- a.receiveFromGeminiWithTracking(writeCh, liveSession, tracker, saveTurn)
+	}()
+	go func() {
+		errCh <- receiveFromClientWithTracking(conn, liveSession, cancel, tracker)
+	}()
+
+	firstErr := <-errCh
+	cancel()
+
+	tracker.flushPending(saveTurn)
+	if tracker.userText != "" || len(tracker.userAudio) > 0 {
+		saveTurn("user", tracker.userText, tracker.userAudio, 16000)
+	}
+	if tracker.phase == phaseModel && (tracker.modelText != "" || len(tracker.modelAudio) > 0) {
+		saveTurn("model", tracker.modelText, tracker.modelAudio, 24000)
+	}
+
+	return firstErr
+}
+
+func (a *Assistant) receiveFromGeminiWithTracking(writeCh chan<- wsServerMessage, liveSession *genai.Session, tracker *turnTracker, saveTurn func(string, string, [][]byte, uint32)) error {
+	for {
+		msg, err := liveSession.Receive()
+		if err != nil {
+			tracker.flushPending(saveTurn)
+			return fmt.Errorf("session.Receive: %w", err)
+		}
+
+		if msg.GoAway != nil {
+			writeCh <- wsServerMessage{Type: serverMsgTypeGoAway}
+		}
+
+		sc := msg.ServerContent
+		if sc == nil {
+			continue
+		}
+
+		if sc.ModelTurn != nil {
+			tracker.handleModelTurn(sc.ModelTurn.Parts, saveTurn, writeCh)
+		}
+		if sc.InputTranscription != nil && sc.InputTranscription.Text != "" {
+			tracker.handleInputTranscription(sc.InputTranscription, saveTurn, writeCh)
+		}
+		if sc.OutputTranscription != nil && sc.OutputTranscription.Text != "" {
+			tracker.handleOutputTranscription(sc.OutputTranscription, saveTurn, writeCh)
+		}
+		if sc.Interrupted {
+			tracker.handleInterrupted(saveTurn, writeCh)
+		}
+		if sc.TurnComplete {
+			tracker.handleTurnComplete(saveTurn, writeCh)
+		}
+	}
+}
+
+func (t *turnTracker) flushPending(saveTurn func(string, string, [][]byte, uint32)) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.pendingTimer != nil {
+		t.pendingTimer.Stop()
+		t.pendingTimer = nil
+	}
+	if len(t.pendingAudio) > 0 || t.pendingText != "" {
+		saveTurn("model", t.pendingText, t.pendingAudio, 24000)
+		t.pendingAudio = nil
+		t.pendingText = ""
+	}
+}
+
+func (t *turnTracker) handleModelTurn(parts []*genai.Part, saveTurn func(string, string, [][]byte, uint32), writeCh chan<- wsServerMessage) {
+	for _, part := range parts {
+		if part.InlineData == nil || len(part.InlineData.Data) == 0 {
+			continue
+		}
+		if t.phase != phaseModel {
+			if t.userText != "" || len(t.userAudio) > 0 {
+				saveTurn("user", t.userText, t.userAudio, 16000)
+			}
+			t.phase = phaseModel
+			t.userAudio = t.userAudio[:0]
+			t.userText = ""
+			t.modelAudio = t.modelAudio[:0]
+			t.modelText = ""
+		}
+		t.modelAudio = append(t.modelAudio, part.InlineData.Data)
+
+		writeCh <- wsServerMessage{
+			Type: serverMsgTypeAudio,
+			Data: base64.StdEncoding.EncodeToString(part.InlineData.Data),
+		}
+	}
+}
+
+func (t *turnTracker) handleInputTranscription(tr *genai.Transcription, saveTurn func(string, string, [][]byte, uint32), writeCh chan<- wsServerMessage) {
+	t.flushPending(saveTurn)
+	if t.phase != phaseUser {
+		if t.phase == phaseModel && (t.modelText != "" || len(t.modelAudio) > 0) {
+			saveTurn("model", t.modelText, t.modelAudio, 24000)
+		}
+		t.phase = phaseUser
+		t.userText = ""
+	}
+	t.userText += tr.Text
+
+	writeCh <- wsServerMessage{
+		Type:     serverMsgTypeInputTranscript,
+		Data:     tr.Text,
+		Finished: tr.Finished,
+	}
+}
+
+func (t *turnTracker) handleOutputTranscription(tr *genai.Transcription, saveTurn func(string, string, [][]byte, uint32), writeCh chan<- wsServerMessage) {
+	t.mu.Lock()
+	hasPending := t.pendingAudio != nil
+	if hasPending {
+		t.pendingText += tr.Text
+	} else {
+		t.modelText += tr.Text
+	}
+	t.mu.Unlock()
+
+	writeCh <- wsServerMessage{
+		Type:     serverMsgTypeOutputTranscript,
+		Data:     tr.Text,
+		Finished: tr.Finished,
+	}
+
+	if tr.Finished && hasPending {
+		t.flushPending(saveTurn)
+	}
+}
+
+func (t *turnTracker) handleInterrupted(saveTurn func(string, string, [][]byte, uint32), writeCh chan<- wsServerMessage) {
+	t.flushPending(saveTurn)
+	if t.phase == phaseModel && (t.modelText != "" || len(t.modelAudio) > 0) {
+		saveTurn("model", t.modelText, t.modelAudio, 24000)
+	}
+	t.phase = phaseWaiting
+	writeCh <- wsServerMessage{Type: serverMsgTypeInterrupted}
+}
+
+func (t *turnTracker) handleTurnComplete(saveTurn func(string, string, [][]byte, uint32), writeCh chan<- wsServerMessage) {
+	slog.Info("handleTurnComplete", "phase", t.phase, "modelTextLen", len(t.modelText), "modelAudioChunks", len(t.modelAudio))
+	if t.phase == phaseModel && (t.modelText != "" || len(t.modelAudio) > 0) {
+		if t.modelText != "" {
+			saveTurn("model", t.modelText, t.modelAudio, 24000)
+		} else {
+			slog.Info("handleTurnComplete: deferring save (no transcript yet)")
+			t.mu.Lock()
+			t.pendingAudio = make([][]byte, len(t.modelAudio))
+			copy(t.pendingAudio, t.modelAudio)
+			t.pendingText = ""
+			t.pendingTimer = time.AfterFunc(3*time.Second, func() {
+				t.mu.Lock()
+				audio := t.pendingAudio
+				text := t.pendingText
+				t.pendingAudio = nil
+				t.pendingText = ""
+				t.pendingTimer = nil
+				t.mu.Unlock()
+				if len(audio) > 0 || text != "" {
+					saveTurn("model", text, audio, 24000)
+				}
+			})
+			t.mu.Unlock()
+		}
+	}
+	t.phase = phaseWaiting
+	writeCh <- wsServerMessage{Type: serverMsgTypeTurnComplete}
+}
+
+func receiveFromClientWithTracking(conn *websocket.Conn, liveSession *genai.Session, cancel context.CancelFunc, tracker *turnTracker) error {
+	for {
+		_, raw, err := conn.ReadMessage()
+		if err != nil {
+			cancel()
+			return nil
+		}
+
+		var msg wsClientMessage
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			slog.Warn("receiveFromClient: invalid JSON", "err", err)
+			continue
+		}
+
+		switch msg.Type {
+		case clientMsgTypeAudio:
+			pcm, err := base64.StdEncoding.DecodeString(msg.Data)
+			if err != nil {
+				slog.Warn("receiveFromClient: base64 decode error", "err", err)
+				continue
+			}
+			tracker.userAudio = append(tracker.userAudio, pcm)
+
+			if err := liveSession.SendRealtimeInput(genai.LiveRealtimeInput{
+				Audio: &genai.Blob{
+					Data:     pcm,
+					MIMEType: "audio/pcm;rate=16000",
+				},
+			}); err != nil {
+				return fmt.Errorf("SendRealtimeInput: %w", err)
+			}
+
+		case clientMsgTypeEnd:
+			if err := liveSession.SendRealtimeInput(genai.LiveRealtimeInput{
+				AudioStreamEnd: true,
+			}); err != nil {
+				return fmt.Errorf("SendRealtimeInput(end): %w", err)
+			}
+
+		case clientMsgTypeText:
+			if msg.Data == "" {
+				continue
+			}
+			if err := liveSession.SendClientContent(genai.LiveClientContentInput{
+				Turns: []*genai.Content{
+					genai.NewContentFromText(msg.Data, genai.RoleUser),
+				},
+			}); err != nil {
+				return fmt.Errorf("SendClientContent: %w", err)
+			}
+		}
+	}
+}
+
+func (a *Assistant) saveVoiceTurn(ctx context.Context, userID int, sessionID, role, transcript string, audioChunks [][]byte, sampleRate uint32) {
+	if transcript == "" && len(audioChunks) == 0 {
+		slog.Info("saveVoiceTurn: skipped (empty)", "role", role, "sessionID", sessionID)
+		return
+	}
+
+	slog.Info("saveVoiceTurn: starting", "role", role, "transcriptLen", len(transcript), "audioChunks", len(audioChunks), "sessionID", sessionID)
+
+	fileID := a.saveVoiceAudio(ctx, userID, sessionID, role, audioChunks, sampleRate)
+
+	metadataJSON, _ := json.Marshal(voiceAudioMetadata{FileID: fileID})
+	messageText := fmt.Sprintf("%s %s -->\n%s", voiceAudioMetadataPrefix, string(metadataJSON), transcript)
+
+	contentRole := genai.RoleUser
+	author := "user"
+	if role == "model" {
+		contentRole = "model"
+		author = "assistant"
+	}
+
+	userIDStr := strconv.Itoa(userID)
+	getResp, err := a.session.Get(ctx, &adksession.GetRequest{
+		AppName:   constant.AppNameAssistant.String(),
+		UserID:    userIDStr,
+		SessionID: sessionID,
+	})
+	if err != nil {
+		slog.Error("saveVoiceTurn: session.Get() error", "err", err)
+		return
+	}
+
+	event := &adksession.Event{
+		ID:        uuid.NewString(),
+		Timestamp: time.Now(),
+		Author:    author,
+		LLMResponse: adkmodel.LLMResponse{
+			Content: &genai.Content{
+				Role:  contentRole,
+				Parts: []*genai.Part{genai.NewPartFromText(messageText)},
+			},
+		},
+	}
+
+	if err := a.session.AppendEvent(ctx, getResp.Session, event); err != nil {
+		slog.Error("saveVoiceTurn: session.AppendEvent() error", "role", role, "err", err)
+	}
+}
+
+func (a *Assistant) saveVoiceAudio(ctx context.Context, userID int, sessionID, role string, audioChunks [][]byte, sampleRate uint32) int {
+	if len(audioChunks) == 0 {
+		return 0
+	}
+
+	var totalLen int
+	for _, chunk := range audioChunks {
+		totalLen += len(chunk)
+	}
+	pcm := make([]byte, 0, totalLen)
+	for _, chunk := range audioChunks {
+		pcm = append(pcm, chunk...)
+	}
+
+	fileName := fmt.Sprintf("voice_%s_%d.wav", role, time.Now().UnixMilli())
+	asset, err := tools.SaveChatAudioAsset(ctx, a.db, a.fileStore, userID, sessionID, fileName, buildWAV(pcm, sampleRate, 1, 16), "audio/wav")
+	if err != nil {
+		slog.Error("saveVoiceAudio: SaveChatAudioAsset failed", "err", err)
+		return 0
+	}
+	slog.Info("saveVoiceAudio: saved", "role", role, "fileID", asset.ID)
+	return asset.ID
+}
+
+func writeWSError(conn *websocket.Conn, errMsg string) {
+	data, _ := json.Marshal(wsServerMessage{Type: serverMsgTypeError, Data: errMsg})
+	conn.WriteMessage(websocket.TextMessage, data)
+}

--- a/internal/app/aiguide/assistant/live_client.go
+++ b/internal/app/aiguide/assistant/live_client.go
@@ -1,0 +1,30 @@
+package assistant
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"google.golang.org/genai"
+)
+
+func newLiveClient(ctx context.Context, apiKey, baseURL string, httpClient *http.Client) (*genai.Client, error) {
+	cfg := &genai.ClientConfig{
+		APIKey:     apiKey,
+		HTTPClient: httpClient,
+		HTTPOptions: genai.HTTPOptions{
+			APIVersion: "v1alpha",
+		},
+	}
+	if baseURL != "" {
+		cfg.HTTPOptions.BaseURL = baseURL
+	}
+
+	client, err := genai.NewClient(ctx, cfg)
+	if err != nil {
+		slog.Error("genai.NewClient (live) error", "err", err)
+		return nil, fmt.Errorf("genai.NewClient (live): %w", err)
+	}
+	return client, nil
+}

--- a/internal/app/aiguide/assistant/live_protocol.go
+++ b/internal/app/aiguide/assistant/live_protocol.go
@@ -1,0 +1,29 @@
+package assistant
+
+const (
+	clientMsgTypeAudio = "audio"
+	clientMsgTypeEnd   = "end"
+	clientMsgTypeText  = "text"
+)
+
+const (
+	serverMsgTypeSetupOK          = "setup_ok"
+	serverMsgTypeAudio            = "audio"
+	serverMsgTypeInputTranscript  = "input_transcript"
+	serverMsgTypeOutputTranscript = "output_transcript"
+	serverMsgTypeTurnComplete     = "turn_complete"
+	serverMsgTypeInterrupted      = "interrupted"
+	serverMsgTypeError            = "error"
+	serverMsgTypeGoAway           = "go_away"
+)
+
+type wsClientMessage struct {
+	Type string `json:"type"`
+	Data string `json:"data,omitempty"`
+}
+
+type wsServerMessage struct {
+	Type     string `json:"type"`
+	Data     string `json:"data,omitempty"`
+	Finished bool   `json:"finished,omitempty"`
+}

--- a/internal/app/aiguide/assistant/pdf_message_parts.go
+++ b/internal/app/aiguide/assistant/pdf_message_parts.go
@@ -19,6 +19,7 @@ import (
 const maxInlinePDFExtractChars = 12000
 const pdfFileMetadataPrefix = "<!-- PDF_FILE:"
 const audioFileMetadataPrefix = "<!-- AUDIO_FILE:"
+const voiceAudioMetadataPrefix = "<!-- VOICE_AUDIO:"
 
 type pdfFileMetadata struct {
 	Name string `json:"name,omitempty"`
@@ -27,6 +28,10 @@ type pdfFileMetadata struct {
 type audioFileMetadata struct {
 	Name   string `json:"name,omitempty"`
 	FileID int    `json:"file_id,omitempty"`
+}
+
+type voiceAudioMetadata struct {
+	FileID int `json:"file_id,omitempty"`
 }
 
 func appendTextPart(parts []*genai.Part, message string, fileNames []string, uploadCount int) []*genai.Part {
@@ -165,17 +170,8 @@ func buildPDFExtractedTextPart(fileName string, result *tools.SaveChatPDFAssetRe
 }
 
 func extractPDFFileNameFromText(text string) (string, bool) {
-	if !strings.HasPrefix(text, pdfFileMetadataPrefix) {
-		return "", false
-	}
-
-	endIdx := strings.Index(text, "-->")
-	if endIdx <= 0 {
-		return "", false
-	}
-
-	metaStr := strings.TrimSpace(text[len(pdfFileMetadataPrefix):endIdx])
-	if metaStr == "" {
+	metaStr, _, ok := parseMetadataComment(text, pdfFileMetadataPrefix)
+	if !ok {
 		return "", false
 	}
 
@@ -213,4 +209,34 @@ func buildAudioUploadedPart(fileName string, fileID int) *genai.Part {
 	builder.WriteString("If the user asks to read or transcribe this audio, use file_list/file_get to confirm the file_id and then call audio_transcribe.")
 
 	return genai.NewPartFromText(builder.String())
+}
+
+func parseMetadataComment(text, prefix string) (jsonStr, remaining string, ok bool) {
+	if !strings.HasPrefix(text, prefix) {
+		return "", "", false
+	}
+	endIdx := strings.Index(text, "-->")
+	if endIdx <= 0 {
+		return "", "", false
+	}
+	jsonStr = strings.TrimSpace(text[len(prefix):endIdx])
+	if jsonStr == "" {
+		return "", "", false
+	}
+	remaining = strings.TrimPrefix(text[endIdx+3:], "\n")
+	return jsonStr, remaining, true
+}
+
+func extractVoiceAudioMetadata(text string) (fileID int, transcript string, ok bool) {
+	metaStr, remaining, ok := parseMetadataComment(text, voiceAudioMetadataPrefix)
+	if !ok {
+		return 0, "", false
+	}
+
+	var metadata voiceAudioMetadata
+	if err := json.Unmarshal([]byte(metaStr), &metadata); err != nil {
+		return 0, "", false
+	}
+
+	return metadata.FileID, remaining, true
 }

--- a/internal/app/aiguide/assistant/session.go
+++ b/internal/app/aiguide/assistant/session.go
@@ -56,16 +56,17 @@ type SessionHistoryResponse struct {
 
 // MessageEvent 定义消息事件结构
 type MessageEvent struct {
-	ID        string        `json:"id"`
-	Timestamp time.Time     `json:"timestamp"`
-	Role      string        `json:"role"` // "user" or "assistant"
-	Content   string        `json:"content"`
-	Thought   string        `json:"thought,omitempty"`
-	Images    []string      `json:"images,omitempty"`     // Base64编码的图片列表
-	Videos    []string      `json:"videos,omitempty"`     // 视频文件URL列表
-	FileNames []string      `json:"file_names,omitempty"` // 文件名列表，与 Images 对应
-	Files     []MessageFile `json:"files,omitempty"`
-	ToolCalls []ToolCall    `json:"tool_calls,omitempty"`
+	ID               string        `json:"id"`
+	Timestamp        time.Time     `json:"timestamp"`
+	Role             string        `json:"role"` // "user" or "assistant"
+	Content          string        `json:"content"`
+	Thought          string        `json:"thought,omitempty"`
+	Images           []string      `json:"images,omitempty"`
+	Videos           []string      `json:"videos,omitempty"`
+	FileNames        []string      `json:"file_names,omitempty"`
+	Files            []MessageFile `json:"files,omitempty"`
+	ToolCalls        []ToolCall    `json:"tool_calls,omitempty"`
+	VoiceAudioFileID int           `json:"voice_audio_file_id,omitempty"`
 }
 
 type MessageFile struct {
@@ -383,6 +384,7 @@ func buildMessageEvents(events session.Events, locale string) []MessageEvent {
 		var fileNames []string
 		var files []MessageFile
 		var toolCalls []ToolCall
+		voiceAudioFileID := 0
 		localToolCallIDs := make([]string, 0)
 		localFunctionResponses := make(map[string]map[string]any)
 		hasFunctionResponse := false
@@ -401,6 +403,11 @@ func buildMessageEvents(events session.Events, locale string) []MessageEvent {
 						Name:     fileName,
 						Label:    label,
 					})
+					continue
+				}
+				if fileID, transcript, ok := extractVoiceAudioMetadata(part.Text); ok {
+					voiceAudioFileID = fileID
+					content += transcript
 					continue
 				}
 				text := part.Text
@@ -489,18 +496,19 @@ func buildMessageEvents(events session.Events, locale string) []MessageEvent {
 			role = "assistant"
 		}
 
-		if content != "" || thought != "" || len(images) > 0 || len(videos) > 0 || len(files) > 0 || len(toolCalls) > 0 {
+		if content != "" || thought != "" || len(images) > 0 || len(videos) > 0 || len(files) > 0 || len(toolCalls) > 0 || voiceAudioFileID > 0 {
 			message := MessageEvent{
-				ID:        event.ID,
-				Timestamp: event.Timestamp,
-				Role:      role,
-				Content:   content,
-				Thought:   thought,
-				Images:    images,
-				Videos:    videos,
-				FileNames: fileNames,
-				Files:     files,
-				ToolCalls: toolCalls,
+				ID:               event.ID,
+				Timestamp:        event.Timestamp,
+				Role:             role,
+				Content:          content,
+				Thought:          thought,
+				Images:           images,
+				Videos:           videos,
+				FileNames:        fileNames,
+				Files:            files,
+				ToolCalls:        toolCalls,
+				VoiceAudioFileID: voiceAudioFileID,
 			}
 			if isDuplicateRetryUserMessage(allMessages, message) {
 				continue

--- a/internal/app/aiguide/router.go
+++ b/internal/app/aiguide/router.go
@@ -44,6 +44,9 @@ func (a *AIGuide) initRouter(engine *gin.Engine) error {
 	// Text-to-speech streaming endpoint
 	api.POST("/assistant/tts/stream", a.assistant.TextToSpeechStream)
 
+	// Real-time voice conversation via Gemini Live API (WebSocket)
+	api.GET("/assistant/live", a.assistant.VoiceCall)
+
 	// Share management routes (authenticated)
 	shareGroup := api.Group("/assistant/share")
 	{


### PR DESCRIPTION
## Summary
- Add three-tier WebSocket bridge (Browser ↔ Go Backend ↔ Gemini Live API) for bidirectional audio streaming with live transcription
- Backend: WebSocket handler with turn tracking state machine, serialized save channel, deferred transcript save, WAV encoding and audio persistence
- Frontend: `useVoiceCall` hook for mic capture/PCM playback/WS lifecycle, Phone button in ChatInput, AudioWaveform animation during AI speech, VoiceAudioPlayer for recorded voice turns

## New files
- `internal/app/aiguide/assistant/live_api.go` — WebSocket handler + turn tracker
- `internal/app/aiguide/assistant/live_client.go` — Dedicated Live API client (v1alpha)
- `internal/app/aiguide/assistant/live_protocol.go` — WS message type definitions
- `frontend/app/chat/[sessionId]/hooks/useVoiceCall.ts` — Voice call React hook
- `frontend/app/chat/[sessionId]/components/AudioWaveform.tsx` — Animated waveform
- `frontend/app/chat/[sessionId]/components/VoiceAudioPlayer.tsx` — Audio playback component

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `pnpm verify` (lint + test + build) passes
- [ ] Manual: start voice call, speak, verify user transcript + audio appear in real time
- [ ] Manual: verify AI audio plays back with waveform animation
- [ ] Manual: verify voice call works from empty session (no prior messages)
- [ ] Manual: end call and verify all messages persisted in session history