### PR TITLE
fix: update Docker Go version to match go.mod (1.26.1)

### DIFF
--- a/deployments/docker/Dockerfile.backend
+++ b/deployments/docker/Dockerfile.backend
@@ -1,5 +1,5 @@
 # 构建阶段
-FROM golang:1.25.5-alpine AS builder
+FROM golang:1.26.1-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Update `Dockerfile.backend` Go base image from `1.25.5` to `1.26.1` to match the `go.mod` requirement, fixing Docker build failures.

## Test plan
- [ ] Verify `make build` succeeds