### PR TITLE
fix: show error when Gemini Live session fails after setup_ok

### DIFF
--- a/frontend/app/chat/[sessionId]/components/ChatInput.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatInput.tsx
@@ -31,6 +31,7 @@ interface ChatInputProps {
   voiceError?: string | null;
   isVoiceCallActive?: boolean;
   onVoiceCallToggle?: () => void;
+  voiceCallError?: string | null;
 }
 
 const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(({ 
@@ -59,6 +60,7 @@ const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(({
   voiceError,
   isVoiceCallActive = false,
   onVoiceCallToggle,
+  voiceCallError,
 }, textareaRef) => {
   const imageInputRef = useRef<HTMLInputElement>(null);
 
@@ -123,6 +125,11 @@ const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(({
           {voiceError && (
             <div className="px-3 pt-2 text-xs text-red-500" role="alert" aria-live="polite">
               {voiceError}
+            </div>
+          )}
+          {voiceCallError && (
+            <div className="px-3 pt-2 text-xs text-red-500" role="alert" aria-live="polite">
+              {voiceCallError}
             </div>
           )}
           <form onSubmit={onSubmit} className="w-full flex items-center p-2 gap-2">

--- a/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
@@ -258,6 +258,7 @@ export function ChatPageLayout({
     voiceError,
     isVoiceCallActive,
     onVoiceCallToggle,
+    voiceCallError,
   };
 
   return (

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.18.0 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/gorilla/websocket v1.5.3
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/internal/app/aiguide/assistant/live_api.go
+++ b/internal/app/aiguide/assistant/live_api.go
@@ -105,7 +105,9 @@ func (a *Assistant) VoiceCall(ctx *gin.Context) {
 	firstErr := a.bridgeVoiceCall(connCtx, connCancel, writeCh, liveSession, conn, saveTurn, userID, sessionID, sessionWriteCh)
 
 	if firstErr != nil {
-		slog.Info("VoiceCall: session ended", "reason", firstErr.Error(), "userID", userID)
+		slog.Info("VoiceCall: session ended with error", "reason", firstErr.Error(), "userID", userID)
+		// Send error to client before the deferred close(writeCh) shuts down wsWriter.
+		writeCh <- wsServerMessage{Type: serverMsgTypeError, Data: firstErr.Error()}
 	} else {
 		slog.Info("VoiceCall: session ended normally", "userID", userID)
 	}


### PR DESCRIPTION
## Summary

- When the Gemini Live session failed after `setup_ok` was already sent (e.g. `Receive()` returned an error from Gemini), the backend silently closed the WebSocket — the frontend returned to idle with no feedback
- Forward the error to the client so users see what went wrong
- Surface `voiceCallError` inside `ChatInput` so it's visible on empty sessions (the existing error block only renders in the non-empty state)
- Promote `gorilla/websocket` to a direct dependency in `go.mod`

## Test plan

- [ ] Start a voice call; confirm that connection errors are now shown in the input box
- [ ] Verify the error message disappears when starting a new call attempt