### PR TITLE
fix: use same-origin WebSocket URL in production (HTTPS)

### DIFF
--- a/frontend/app/chat/[sessionId]/hooks/useVoiceCall.ts
+++ b/frontend/app/chat/[sessionId]/hooks/useVoiceCall.ts
@@ -34,6 +34,11 @@ function getBackendWsUrl(): string {
   }
   if (typeof window !== 'undefined') {
     const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    // In production (HTTPS) use same-origin so Caddy can proxy to the backend.
+    // In development (HTTP) connect directly to the backend port.
+    if (window.location.protocol === 'https:') {
+      return `${proto}://${window.location.hostname}`;
+    }
     return `${proto}://${window.location.hostname}:8080`;
   }
   return 'ws://localhost:8080';


### PR DESCRIPTION
## Summary

- In production (HTTPS), `getBackendWsUrl()` was returning `wss://hostname:8080`, but the backend port 8080 is not publicly exposed and has no TLS
- In HTTPS mode, now uses same-origin (`wss://hostname`) so the request goes through Caddy, which routes `/api/assistant/live*` to the backend
- Development (HTTP) still connects directly to `ws://localhost:8080` as before

## Server-side changes (already applied)

- `docker-compose.yaml`: exposed backend on `127.0.0.1:8082:8080` (localhost only)
- `Caddyfile`: added `route /api/assistant/live* { reverse_proxy 172.17.0.1:8082 }` before the catch-all

## Test plan

- [ ] Voice call works on production (`https://s6-outheart.lol`)
- [ ] Voice call still works in local development (`http://localhost:3000`)