### PR TITLE
fix: restore correct message order after voice call ends

### DIFF
--- a/frontend/app/chat/ChatPageClient.tsx
+++ b/frontend/app/chat/ChatPageClient.tsx
@@ -138,6 +138,16 @@ export default function ChatPageClient() {
     return stopTitlePoll;
   }, [voiceCallStatus, sessionId, startTitlePoll, stopTitlePoll]);
 
+  // When voice call ends, reload session history (voice messages get saved to DB).
+  const prevVoiceCallStatusRef = useRef(voiceCallStatus);
+  useEffect(() => {
+    const prev = prevVoiceCallStatusRef.current;
+    prevVoiceCallStatusRef.current = voiceCallStatus;
+    if (prev === 'connected' && voiceCallStatus === 'idle' && sessionId) {
+      loadSessionHistory(sessionId, true);
+    }
+  }, [voiceCallStatus, sessionId, loadSessionHistory]);
+
   const handleVoiceCallToggle = useCallback(() => {
     if (isVoiceCallActive) {
       endCall();

--- a/frontend/app/chat/[sessionId]/hooks/useVoiceCall.ts
+++ b/frontend/app/chat/[sessionId]/hooks/useVoiceCall.ts
@@ -220,6 +220,7 @@ export function useVoiceCall(sessionId?: string): UseVoiceCallResult {
     currentUserMsgIdRef.current = null;
     currentModelMsgIdRef.current = null;
 
+    setVoiceMessages([]);
     setStatus('idle');
   }, [stopToolCallSound]);
 


### PR DESCRIPTION
## Summary

- Voice messages were persisted in local state after a call ended, causing new text messages to render *above* the voice conversation in `processedMessages`
- `cleanup()` in `useVoiceCall` now clears `voiceMessages` so the hook owns its full state lifecycle
- After a `connected → idle` transition, `ChatPageClient` reloads session history from the backend (where voice messages are saved) to restore them as regular messages in the correct position
- Guard narrows the history reload to `connected → idle` only — failed connections (`connecting → idle`) no longer trigger an unnecessary fetch

## Test plan

- [ ] Start a session, send text messages, start a voice call, have a voice conversation, end the call, then send a new text message — verify it appears *below* the voice messages
- [ ] Verify a failed/rejected voice connection does not trigger a session history reload
- [ ] Verify starting a new voice call still clears the previous voice messages