### PR TITLE
fix: unify AI voice message layout to group audio and text together

### DIFF
--- a/frontend/app/chat/[sessionId]/components/ChatMessagesPane.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatMessagesPane.tsx
@@ -123,14 +123,31 @@ export const ChatMessagesPane = memo(function ChatMessagesPane({
           >
           {message.role === 'assistant' ? (
             <div className="w-full">
-              {message.isVoiceMessage && message.isStreaming ? (
-                <AudioWaveform className="text-zinc-400 dark:text-zinc-500 mb-2" />
-              ) : resolveVoiceAudioUrl(message.voiceAudioFileId, message.voiceAudioUrl) ? (
-                <VoiceAudioPlayer
-                  audioUrl={resolveVoiceAudioUrl(message.voiceAudioFileId, message.voiceAudioUrl)!}
-                  className="max-w-sm mb-2"
-                />
-              ) : null}
+              {(message.isVoiceMessage || resolveVoiceAudioUrl(message.voiceAudioFileId, message.voiceAudioUrl)) ? (
+                <div className="flex flex-col gap-1">
+                  {message.isVoiceMessage && message.isStreaming ? (
+                    <AudioWaveform className="text-zinc-400 dark:text-zinc-500" />
+                  ) : resolveVoiceAudioUrl(message.voiceAudioFileId, message.voiceAudioUrl) ? (
+                    <VoiceAudioPlayer
+                      audioUrl={resolveVoiceAudioUrl(message.voiceAudioFileId, message.voiceAudioUrl)!}
+                      className="max-w-sm"
+                    />
+                  ) : null}
+                  <div className="relative text-sm leading-relaxed" data-ai-message="">
+                    <AIMessageContent
+                      id={message.id}
+                      content={message.content}
+                      thought={message.thought}
+                      isStreaming={message.isStreaming}
+                      images={message.images}
+                      videos={message.videos}
+                      isError={message.isError}
+                      onRetry={onRetry}
+                      toolCalls={message.toolCalls}
+                    />
+                  </div>
+                </div>
+              ) : (
               <div className="relative text-sm w-full leading-relaxed" data-ai-message="">
                 <AIMessageContent
                   id={message.id}
@@ -144,6 +161,7 @@ export const ChatMessagesPane = memo(function ChatMessagesPane({
                   toolCalls={message.toolCalls}
                 />
               </div>
+              )}
             </div>
           ) : (
             <div className="flex gap-2 sm:gap-3 md:gap-4 max-w-[95%] sm:max-w-[90%] md:max-w-[85%] min-w-0 flex-row-reverse">


### PR DESCRIPTION
## Summary
- AI 语音消息的音频播放器和文字现在放在同一个紧凑容器内（`flex-col gap-1`），视觉上形成一个整体
- 之前音频和文字作为独立的兄弟元素渲染，看起来是分开的两条消息
- 非语音的 AI 消息保持原有的全宽无背景样式不变

## Test plan
- [ ] 发起语音通话，确认 AI 回复的音频和文字紧凑显示在一起
- [ ] 确认用户语音消息样式不受影响
- [ ] 确认普通文字消息（非语音）渲染正常
- [ ] 确认历史语音消息加载后也能正确显示