### PR TITLE
fix: route text and image messages through WebSocket during voice calls

### DIFF
--- a/frontend/app/chat/ChatPageClient.tsx
+++ b/frontend/app/chat/ChatPageClient.tsx
@@ -126,6 +126,7 @@ export default function ChatPageClient() {
     voiceMessages,
     startCall,
     endCall,
+    sendText: voiceCallSendText,
     error: voiceCallError,
   } = useVoiceCall(sessionId);
 
@@ -176,6 +177,7 @@ export default function ChatPageClient() {
           isStreaming: !vm.isComplete,
           voiceAudioUrl: vm.audioUrl ?? undefined,
           isVoiceMessage: true,
+          images: vm.images,
         });
       }
     }
@@ -294,14 +296,38 @@ export default function ChatPageClient() {
 
   const canSend = actions.canSend(selectedImages);
 
+  const sendTextDuringVoiceCall = useCallback(
+    (e: React.FormEvent | React.KeyboardEvent) => {
+      e.preventDefault();
+      const text = actions.quotedText
+        ? `> ${actions.quotedText.split('\n').join('\n> ')}\n\n${actions.inputValue}`.trim()
+        : actions.inputValue.trim();
+      const imageDataUrls = selectedImages.map((img) => img.dataUrl);
+      if (!text && imageDataUrls.length === 0) return;
+      voiceCallSendText(text, imageDataUrls.length > 0 ? imageDataUrls : undefined);
+      actions.setInputValue('');
+      actions.setQuotedText('');
+      clearImages();
+    },
+    [actions, clearImages, selectedImages, voiceCallSendText]
+  );
+
   const handleSubmit = useCallback(
-    (e: React.FormEvent) => actions.handleSubmit(e, selectedImages),
-    [actions, selectedImages]
+    (e: React.FormEvent) => {
+      if (isVoiceCallActive) return sendTextDuringVoiceCall(e);
+      actions.handleSubmit(e, selectedImages);
+    },
+    [actions, isVoiceCallActive, selectedImages, sendTextDuringVoiceCall]
   );
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => actions.handleKeyDown(e, selectedImages),
-    [actions, selectedImages]
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (isVoiceCallActive && e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+        return sendTextDuringVoiceCall(e);
+      }
+      actions.handleKeyDown(e, selectedImages);
+    },
+    [actions, isVoiceCallActive, selectedImages, sendTextDuringVoiceCall]
   );
 
   const handleSubmitRenameProject = useCallback(

--- a/frontend/app/chat/[sessionId]/hooks/useVoiceCall.ts
+++ b/frontend/app/chat/[sessionId]/hooks/useVoiceCall.ts
@@ -10,6 +10,7 @@ export interface VoiceMessage {
   audioUrl: string | null;
   transcript: string;
   isComplete: boolean;
+  images?: string[];
 }
 
 interface UseVoiceCallResult {
@@ -17,6 +18,7 @@ interface UseVoiceCallResult {
   voiceMessages: VoiceMessage[];
   startCall: (overrideSessionId?: string) => Promise<void>;
   endCall: () => void;
+  sendText: (text: string, images?: string[]) => void;
   error: string | null;
 }
 
@@ -449,7 +451,26 @@ export function useVoiceCall(sessionId?: string): UseVoiceCallResult {
     cleanup();
   }, [cleanup, finalizeModelTurn, finalizeUserTurn]);
 
-  return { status, voiceMessages, startCall, endCall, error };
+  const sendText = useCallback((text: string, images?: string[]) => {
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+
+    if (turnPhaseRef.current === 'user') finalizeUserTurn();
+    if (turnPhaseRef.current === 'model') finalizeModelTurn();
+    turnPhaseRef.current = 'waiting';
+
+    setVoiceMessages((prev) => [
+      ...prev,
+      { id: genId(), role: 'user', audioUrl: null, transcript: text, isComplete: true, images },
+    ]);
+
+    const payload: Record<string, unknown> = { type: 'text', data: text };
+    if (images && images.length > 0) {
+      payload.images = images;
+    }
+    wsRef.current.send(JSON.stringify(payload));
+  }, [finalizeModelTurn, finalizeUserTurn]);
+
+  return { status, voiceMessages, startCall, endCall, sendText, error };
 }
 
 function handleInputTranscript(

--- a/internal/app/aiguide/assistant/live_api.go
+++ b/internal/app/aiguide/assistant/live_api.go
@@ -102,10 +102,10 @@ func (a *Assistant) VoiceCall(ctx *gin.Context) {
 
 	writeCh <- wsServerMessage{Type: serverMsgTypeSetupOK}
 
-	saveTurn, waitSaves := a.startSaveLoop(userID, sessionID)
+	saveTurn, saveImageTurn, waitSaves := a.startSaveLoop(userID, sessionID)
 	defer waitSaves()
 
-	firstErr := a.bridgeVoiceCall(connCtx, connCancel, writeCh, liveSession, conn, saveTurn, userID, sessionID, sessionWriteCh)
+	firstErr := a.bridgeVoiceCall(connCtx, connCancel, writeCh, liveSession, conn, saveTurn, saveImageTurn, userID, sessionID, sessionWriteCh)
 
 	if firstErr != nil {
 		slog.Info("VoiceCall: session ended with error", "reason", firstErr.Error(), "userID", userID)
@@ -186,9 +186,10 @@ type saveRequest struct {
 	text       string
 	audio      [][]byte
 	sampleRate uint32
+	imageParts []*genai.Part
 }
 
-func (a *Assistant) startSaveLoop(userID int, sessionID string) (saveTurn func(string, string, [][]byte, uint32), wait func()) {
+func (a *Assistant) startSaveLoop(userID int, sessionID string) (saveTurn func(string, string, [][]byte, uint32), saveImageTurn func(string, []*genai.Part), wait func()) {
 	saveCh := make(chan saveRequest, 16)
 	saveDone := make(chan struct{})
 	var firstUserTranscript string
@@ -197,7 +198,11 @@ func (a *Assistant) startSaveLoop(userID int, sessionID string) (saveTurn func(s
 	go func() {
 		defer close(saveDone)
 		for req := range saveCh {
-			a.saveVoiceTurn(context.Background(), userID, sessionID, req.role, req.text, req.audio, req.sampleRate)
+			if len(req.imageParts) > 0 {
+				a.saveTextImageTurn(context.Background(), userID, sessionID, req.text, req.imageParts)
+			} else {
+				a.saveVoiceTurn(context.Background(), userID, sessionID, req.role, req.text, req.audio, req.sampleRate)
+			}
 			if req.role != "user" || req.text == "" {
 				continue
 			}
@@ -224,6 +229,11 @@ func (a *Assistant) startSaveLoop(userID int, sessionID string) (saveTurn func(s
 		saveCh <- saveRequest{role: role, text: text, audio: copied, sampleRate: sampleRate}
 	}
 
+	saveImageTurn = func(text string, imageParts []*genai.Part) {
+		slog.Info("saveImageTurn: queued", "textLen", len(text), "imageParts", len(imageParts))
+		saveCh <- saveRequest{role: "user", text: text, imageParts: imageParts}
+	}
+
 	wait = func() {
 		close(saveCh)
 		<-saveDone
@@ -245,6 +255,7 @@ func (a *Assistant) bridgeVoiceCall(
 	liveSession *genai.Session,
 	conn *websocket.Conn,
 	saveTurn func(string, string, [][]byte, uint32),
+	saveImageTurn func(string, []*genai.Part),
 	userID int,
 	sessionID string,
 	sessionWriteCh chan<- func() error,
@@ -273,7 +284,7 @@ func (a *Assistant) bridgeVoiceCall(
 				errCh <- fmt.Errorf("panic in receiveFromClient: %v", r)
 			}
 		}()
-		errCh <- receiveFromClientWithTracking(ctx, conn, liveSession, cancel, tracker, sessionWriteCh)
+		errCh <- receiveFromClientWithTracking(ctx, conn, liveSession, cancel, tracker, saveTurn, saveImageTurn, sessionWriteCh)
 	}()
 
 	firstErr := <-errCh
@@ -430,6 +441,30 @@ func (t *turnTracker) handleInterrupted(saveTurn func(string, string, [][]byte, 
 	writeCh <- wsServerMessage{Type: serverMsgTypeInterrupted}
 }
 
+func (t *turnTracker) finalizePendingTurns(saveTurn func(string, string, [][]byte, uint32)) {
+	t.flushPending(saveTurn)
+	switch t.phase {
+	case phaseUser:
+		if t.userText != "" || len(t.userAudio) > 0 {
+			saveTurn("user", t.userText, t.userAudio, 16000)
+		}
+	case phaseModel:
+		if t.modelText != "" || len(t.modelAudio) > 0 {
+			saveTurn("model", t.modelText, t.modelAudio, 24000)
+		}
+	}
+	t.phase = phaseWaiting
+	t.userAudio = t.userAudio[:0]
+	t.userText = ""
+	t.modelAudio = t.modelAudio[:0]
+	t.modelText = ""
+}
+
+func (t *turnTracker) handleTextInput(text string, saveTurn func(string, string, [][]byte, uint32)) {
+	t.finalizePendingTurns(saveTurn)
+	saveTurn("user", text, nil, 0)
+}
+
 func (t *turnTracker) handleTurnComplete(saveTurn func(string, string, [][]byte, uint32), writeCh chan<- wsServerMessage) {
 	slog.Info("handleTurnComplete", "phase", t.phase, "modelTextLen", len(t.modelText), "modelAudioChunks", len(t.modelAudio))
 	if t.phase == phaseModel && (t.modelText != "" || len(t.modelAudio) > 0) {
@@ -460,7 +495,7 @@ func (t *turnTracker) handleTurnComplete(saveTurn func(string, string, [][]byte,
 	writeCh <- wsServerMessage{Type: serverMsgTypeTurnComplete}
 }
 
-func receiveFromClientWithTracking(ctx context.Context, conn *websocket.Conn, liveSession *genai.Session, cancel context.CancelFunc, tracker *turnTracker, sessionWriteCh chan<- func() error) error {
+func receiveFromClientWithTracking(ctx context.Context, conn *websocket.Conn, liveSession *genai.Session, cancel context.CancelFunc, tracker *turnTracker, saveTurn func(string, string, [][]byte, uint32), saveImageTurn func(string, []*genai.Part), sessionWriteCh chan<- func() error) error {
 	for {
 		_, raw, err := conn.ReadMessage()
 		if err != nil {
@@ -502,14 +537,43 @@ func receiveFromClientWithTracking(ctx context.Context, conn *websocket.Conn, li
 			}
 
 		case clientMsgTypeText:
-			if msg.Data == "" {
+			if msg.Data == "" && len(msg.Images) == 0 {
 				continue
 			}
 			text := msg.Data
+
+			var imageParts []*genai.Part
+			for _, dataURI := range msg.Images {
+				imgBytes, mimeType, err := parseDataURI(dataURI)
+				if err != nil {
+					slog.Warn("receiveFromClient: image parseDataURI error", "err", err)
+					continue
+				}
+				if !strings.HasPrefix(mimeType, "image/") {
+					slog.Warn("receiveFromClient: skipping non-image file", "mimeType", mimeType)
+					continue
+				}
+				imageParts = append(imageParts, genai.NewPartFromBytes(imgBytes, mimeType))
+			}
+
+			if len(imageParts) > 0 {
+				tracker.finalizePendingTurns(saveTurn)
+				saveImageTurn(text, imageParts)
+			} else if text != "" {
+				tracker.handleTextInput(text, saveTurn)
+			} else {
+				continue
+			}
+
+			parts := make([]*genai.Part, 0, 1+len(imageParts))
+			if text != "" {
+				parts = append(parts, genai.NewPartFromText(text))
+			}
+			parts = append(parts, imageParts...)
 			select {
 			case sessionWriteCh <- func() error {
 				return liveSession.SendClientContent(genai.LiveClientContentInput{
-					Turns: []*genai.Content{genai.NewContentFromText(text, genai.RoleUser)},
+					Turns: []*genai.Content{{Role: genai.RoleUser, Parts: parts}},
 				})
 			}:
 			case <-ctx.Done():
@@ -529,8 +593,13 @@ func (a *Assistant) saveVoiceTurn(ctx context.Context, userID int, sessionID, ro
 
 	fileID := a.saveVoiceAudio(ctx, userID, sessionID, role, audioChunks, sampleRate)
 
-	metadataJSON, _ := json.Marshal(voiceAudioMetadata{FileID: fileID})
-	messageText := fmt.Sprintf("%s %s -->\n%s", voiceAudioMetadataPrefix, string(metadataJSON), transcript)
+	var messageText string
+	if len(audioChunks) > 0 {
+		metadataJSON, _ := json.Marshal(voiceAudioMetadata{FileID: fileID})
+		messageText = fmt.Sprintf("%s %s -->\n%s", voiceAudioMetadataPrefix, string(metadataJSON), transcript)
+	} else {
+		messageText = transcript
+	}
 
 	contentRole := genai.RoleUser
 	author := "user"
@@ -564,6 +633,47 @@ func (a *Assistant) saveVoiceTurn(ctx context.Context, userID int, sessionID, ro
 
 	if err := a.session.AppendEvent(ctx, getResp.Session, event); err != nil {
 		slog.Error("saveVoiceTurn: session.AppendEvent() error", "role", role, "err", err)
+	}
+}
+
+func (a *Assistant) saveTextImageTurn(ctx context.Context, userID int, sessionID, text string, imageParts []*genai.Part) {
+	if text == "" && len(imageParts) == 0 {
+		return
+	}
+
+	slog.Info("saveTextImageTurn: starting", "textLen", len(text), "imageParts", len(imageParts), "sessionID", sessionID)
+
+	parts := make([]*genai.Part, 0, 1+len(imageParts))
+	if text != "" {
+		parts = append(parts, genai.NewPartFromText(text))
+	}
+	parts = append(parts, imageParts...)
+
+	userIDStr := strconv.Itoa(userID)
+	getResp, err := a.session.Get(ctx, &adksession.GetRequest{
+		AppName:   constant.AppNameAssistant.String(),
+		UserID:    userIDStr,
+		SessionID: sessionID,
+	})
+	if err != nil {
+		slog.Error("saveTextImageTurn: session.Get() error", "err", err)
+		return
+	}
+
+	event := &adksession.Event{
+		ID:        uuid.NewString(),
+		Timestamp: time.Now(),
+		Author:    "user",
+		LLMResponse: adkmodel.LLMResponse{
+			Content: &genai.Content{
+				Role:  genai.RoleUser,
+				Parts: parts,
+			},
+		},
+	}
+
+	if err := a.session.AppendEvent(ctx, getResp.Session, event); err != nil {
+		slog.Error("saveTextImageTurn: session.AppendEvent() error", "err", err)
 	}
 }
 

--- a/internal/app/aiguide/assistant/live_protocol.go
+++ b/internal/app/aiguide/assistant/live_protocol.go
@@ -20,8 +20,9 @@ const (
 )
 
 type wsClientMessage struct {
-	Type string `json:"type"`
-	Data string `json:"data,omitempty"`
+	Type   string   `json:"type"`
+	Data   string   `json:"data,omitempty"`
+	Images []string `json:"images,omitempty"`
 }
 
 type wsServerMessage struct {


### PR DESCRIPTION
## Summary

- During a voice call, text messages were sent via the SSE Chat endpoint independently of the WebSocket, causing them to appear before voice messages in the chat history
- Route text (and image) submissions through the WebSocket during voice calls so all messages share one save queue (`saveTurn` channel) and maintain correct chronological order
- Add image upload support during voice calls by extending the WebSocket protocol and Gemini Live API `SendClientContent` with mixed content parts

## Changes

**Backend (`live_api.go`, `live_protocol.go`):**
- Add `Images` field to `wsClientMessage` WebSocket protocol
- Extract `finalizePendingTurns` from `handleTextInput` for reuse by both text-only and text+image paths
- Extend save pipeline with `saveImageTurn` function through the same `saveCh` channel for ordering guarantee
- Parse image data URIs via existing `parseDataURI`, validate mime type, send mixed content to Gemini
- Add `saveTextImageTurn` to persist text+image events to ADK session
- Skip voice audio metadata prefix for text-only messages in `saveVoiceTurn`

**Frontend (`useVoiceCall.ts`, `ChatPageClient.tsx`):**
- Add `sendText(text, images?)` method to `useVoiceCall` hook
- Intercept `handleSubmit` and `handleKeyDown` during voice calls to route through WebSocket instead of SSE
- Pass selected images through WebSocket and display in voice message list

## Test plan
- [ ] Start a voice call, speak, then type and send a text message — verify text appears after voice messages
- [ ] Send text + image during voice call — verify both display correctly
- [ ] End voice call — verify reloaded history preserves correct message order
- [ ] `go test ./internal/app/aiguide/assistant/...` passes
- [ ] `cd frontend && pnpm verify` passes