### PR TITLE
refactor: use descriptive log messages instead of function names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,12 +187,13 @@ Follow [Effective Go](https://go.dev/doc/effective_go) and [Google Go Style Guid
 - **At error propagation** (internal calls): DO NOT log — just `fmt.Errorf("...: %w", err)`
 - Log once at the source; never log the same error multiple times
 - Exception: GORM database errors should always log at source
+- **Log message style:** lowercase, no trailing punctuation, describe what happened (not which function failed). Never put function names in the message — use structured attrs for context.
 
 ```go
 // At source:
 resp, err := http.DefaultClient.Do(req)
 if err != nil {
-    slog.Error("http.DefaultClient.Do() error", "url", url, "err", err)
+    slog.Error("failed to fetch page", "url", url, "err", err)
     return nil, fmt.Errorf("请求失败: %w", err)
 }
 

--- a/cmd/aiguide/aiguide.go
+++ b/cmd/aiguide/aiguide.go
@@ -30,23 +30,23 @@ func main() {
 func run(ctx context.Context, file string) error {
 	data, err := os.ReadFile(file)
 	if err != nil {
-		slog.Error("os.ReadFile() error", "err", err)
-		return fmt.Errorf("os.ReadFile() error, err = %w", err)
+		slog.Error("failed to read config file", "err", err)
+		return fmt.Errorf("failed to read config file: %w", err)
 	}
 
 	config := &aiguide.Config{}
 	if err := yaml.Unmarshal(data, config); err != nil {
-		slog.Error("yaml.Unmarshal() error", "err", err)
-		return fmt.Errorf("yaml.Unmarshal() error, err = %w", err)
+		slog.Error("failed to parse config yaml", "err", err)
+		return fmt.Errorf("failed to parse config yaml: %w", err)
 	}
 
 	guide, err := aiguide.New(ctx, config)
 	if err != nil {
-		return fmt.Errorf("aiguide.New() error, err = %w", err)
+		return fmt.Errorf("failed to initialize application: %w", err)
 	}
 
 	if err := guide.Run(ctx); err != nil {
-		return fmt.Errorf("guide.Run() error, err = %w", err)
+		return fmt.Errorf("failed to run application: %w", err)
 	}
 
 	return nil

--- a/internal/app/aiguide/aiguide.go
+++ b/internal/app/aiguide/aiguide.go
@@ -94,7 +94,7 @@ func (a *AIGuide) secureCookie() bool {
 func New(ctx context.Context, config *Config) (*AIGuide, error) {
 	httpClient, err := getHTTPClient(config.Proxy)
 	if err != nil {
-		return nil, fmt.Errorf("getHTTPClient() error, err = %w", err)
+		return nil, fmt.Errorf("failed to create http client: %w", err)
 	}
 
 	genaiConfig := &genai.ClientConfig{
@@ -108,14 +108,14 @@ func New(ctx context.Context, config *Config) (*AIGuide, error) {
 	// 创建 genai client，用于图片生成等功能
 	genaiClient, err := genai.NewClient(ctx, genaiConfig)
 	if err != nil {
-		slog.Error("genai.NewClient() error", "err", err)
-		return nil, fmt.Errorf("genai.NewClient() error, err = %w", err)
+		slog.Error("failed to create genai client", "err", err)
+		return nil, fmt.Errorf("failed to create genai client: %w", err)
 	}
 
 	model, err := gemini.NewModel(ctx, config.ModelName, genaiConfig)
 	if err != nil {
-		slog.Error("gemini.NewModel() error", "err", err)
-		return nil, fmt.Errorf("gemini.NewModel() error, err = %w", err)
+		slog.Error("failed to create gemini model", "err", err)
+		return nil, fmt.Errorf("failed to create gemini model: %w", err)
 	}
 
 	// Enable WAL journal mode and a generous busy timeout so concurrent
@@ -130,8 +130,8 @@ func New(ctx context.Context, config *Config) (*AIGuide, error) {
 
 	db, err := gorm.Open(dialector, dbConfig)
 	if err != nil {
-		slog.Error("gorm.Open() error", "err", err)
-		return nil, fmt.Errorf("gorm.Open() error, err = %w", err)
+		slog.Error("failed to open database", "err", err)
+		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 
 	migrator := migration.New(db)
@@ -167,7 +167,7 @@ func New(ctx context.Context, config *Config) (*AIGuide, error) {
 	}
 	fileStore, err := storage.NewLocalFileStore(fileStorageDir)
 	if err != nil {
-		return nil, fmt.Errorf("storage.NewLocalFileStore() error, err = %w", err)
+		return nil, fmt.Errorf("failed to create file store: %w", err)
 	}
 	assistantConfig.FileStore = fileStore
 
@@ -188,7 +188,7 @@ func New(ctx context.Context, config *Config) (*AIGuide, error) {
 
 	assistant, err := assistant.New(assistantConfig)
 	if err != nil {
-		return nil, fmt.Errorf("assistant.New() error, err = %w", err)
+		return nil, fmt.Errorf("failed to create assistant: %w", err)
 	}
 
 	guide := &AIGuide{
@@ -201,7 +201,7 @@ func New(ctx context.Context, config *Config) (*AIGuide, error) {
 
 	rdb, err := redis.New(ctx, config.Redis)
 	if err != nil {
-		return nil, fmt.Errorf("redis.New() error, err = %w", err)
+		return nil, fmt.Errorf("failed to create redis client: %w", err)
 	}
 
 	guide.redisClient = rdb
@@ -221,8 +221,8 @@ func getHTTPClient(proxy string) (*http.Client, error) {
 
 	parsedProxyURL, err := url.Parse(proxy)
 	if err != nil {
-		slog.Error("url.Parse() error", "err", err)
-		return nil, fmt.Errorf("url.Parse() error, err = %w", err)
+		slog.Error("failed to parse proxy url", "err", err)
+		return nil, fmt.Errorf("failed to parse proxy url: %w", err)
 	}
 	httpClient := &http.Client{
 		Transport: &http.Transport{
@@ -240,21 +240,21 @@ func getHTTPClient(proxy string) (*http.Client, error) {
 
 func (a *AIGuide) Run(ctx context.Context) error {
 	if err := a.migrator.Run(); err != nil {
-		return fmt.Errorf("a.migrator.Run() error, err = %w", err)
+		return fmt.Errorf("failed to run database migration: %w", err)
 	}
 
 	if err := a.assistant.Run(ctx); err != nil {
-		return fmt.Errorf("a.agentManager.Run() error, err = %w", err)
+		return fmt.Errorf("failed to start assistant: %w", err)
 	}
 
 	engine := gin.Default()
 	if err := a.initRouter(engine); err != nil {
-		return fmt.Errorf("a.initRouter() error, err = %w", err)
+		return fmt.Errorf("failed to initialize router: %w", err)
 	}
 
 	slog.Info("http listen", "port", a.config.GinPort)
 	if err := engine.Run(":" + a.config.GinPort); err != nil {
-		slog.Error("engine.Run() error", "err", err)
+		slog.Error("failed to start http server", "err", err)
 	}
 
 	return nil

--- a/internal/app/aiguide/assistant/assistant.go
+++ b/internal/app/aiguide/assistant/assistant.go
@@ -93,13 +93,13 @@ func New(config *Config) (*Assistant, error) {
 	}
 	session, err := database.NewSessionService(config.DB.Dialector, gormConfig)
 	if err != nil {
-		slog.Error("database.NewSessionService() error", "err", err)
-		return nil, fmt.Errorf("database.NewSessionService() error, err = %w", err)
+		slog.Error("failed to create session service", "err", err)
+		return nil, fmt.Errorf("failed to create session service: %w", err)
 	}
 
 	if err := database.AutoMigrate(session); err != nil {
-		slog.Error("database.AutoMigrate() error", "err", err)
-		return nil, fmt.Errorf("database.AutoMigrate() error, err = %w", err)
+		slog.Error("failed to auto-migrate session database", "err", err)
+		return nil, fmt.Errorf("failed to auto-migrate session database: %w", err)
 	}
 
 	assistant := &Assistant{
@@ -125,7 +125,7 @@ func New(config *Config) (*Assistant, error) {
 
 	allTools, err := createAssistantTools(config)
 	if err != nil {
-		return nil, fmt.Errorf("createAssistantTools() for live: %w", err)
+		return nil, fmt.Errorf("failed to create assistant tools: %w", err)
 	}
 	// Exclude tools that return large binary payloads (images/video) — the Live API
 	// has a strict message size limit and voice sessions are audio-only anyway.
@@ -138,13 +138,13 @@ func New(config *Config) (*Assistant, error) {
 
 	runner, err := assistant.createRunner()
 	if err != nil {
-		return nil, fmt.Errorf("assistant.createRunner() error, err = %w", err)
+		return nil, fmt.Errorf("failed to create runner: %w", err)
 	}
 	assistant.runner = runner
 
 	executorRunner, err := assistant.createExecutorRunner()
 	if err != nil {
-		return nil, fmt.Errorf("assistant.createExecutorRunner() error, err = %w", err)
+		return nil, fmt.Errorf("failed to create executor runner: %w", err)
 	}
 	assistant.executorRunner = executorRunner
 	assistant.scheduler = newScheduler(config.DB, executorRunner, session)

--- a/internal/app/aiguide/assistant/file_asset_api.go
+++ b/internal/app/aiguide/assistant/file_asset_api.go
@@ -26,7 +26,7 @@ func (a *Assistant) DownloadFile(ctx *gin.Context) {
 
 	fileID, err := strconv.Atoi(ctx.Param("fileId"))
 	if err != nil || fileID <= 0 {
-		slog.Error("strconv.Atoi() error", "file_id", ctx.Param("fileId"), "err", err)
+		slog.Error("failed to parse file id", "file_id", ctx.Param("fileId"), "err", err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid file id"})
 		return
 	}
@@ -40,7 +40,7 @@ func (a *Assistant) DownloadFile(ctx *gin.Context) {
 	var asset table.FileAsset
 	if err := a.db.Where("id = ? AND user_id = ?", fileID, userID).First(&asset).Error; err != nil {
 		if err != gorm.ErrRecordNotFound {
-			slog.Error("db.First() error", "file_id", fileID, "user_id", userID, "err", err)
+			slog.Error("failed to query file asset", "file_id", fileID, "user_id", userID, "err", err)
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load file"})
 			return
 		}
@@ -54,7 +54,7 @@ func (a *Assistant) DownloadFile(ctx *gin.Context) {
 
 	rc, err := a.fileStore.Open(ctx, asset.StoragePath)
 	if err != nil {
-		slog.Error("fileStore.Open() error", "storage_path", asset.StoragePath, "err", err)
+		slog.Error("failed to open file from storage", "storage_path", asset.StoragePath, "err", err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to open file"})
 		return
 	}
@@ -66,7 +66,7 @@ func (a *Assistant) DownloadFile(ctx *gin.Context) {
 	ctx.Header("Content-Length", strconv.FormatInt(asset.SizeBytes, 10))
 
 	if _, err := io.Copy(ctx.Writer, rc); err != nil {
-		slog.Error("io.Copy() error", "file_id", fileID, "err", err)
+		slog.Error("failed to write file to response", "file_id", fileID, "err", err)
 	}
 }
 

--- a/internal/app/aiguide/assistant/live_api.go
+++ b/internal/app/aiguide/assistant/live_api.go
@@ -171,7 +171,7 @@ func wsWriter(conn *websocket.Conn, writeCh <-chan wsServerMessage, cancel conte
 	}
 }
 
-func sessionWriter(liveSession *genai.Session, writeCh <-chan func() error, cancel context.CancelFunc) {
+func sessionWriter(_ *genai.Session, writeCh <-chan func() error, cancel context.CancelFunc) {
 	for fn := range writeCh {
 		if err := fn(); err != nil {
 			slog.Error("VoiceCall: liveSession write error", "err", err)
@@ -615,7 +615,7 @@ func (a *Assistant) saveVoiceTurn(ctx context.Context, userID int, sessionID, ro
 		SessionID: sessionID,
 	})
 	if err != nil {
-		slog.Error("saveVoiceTurn: session.Get() error", "err", err)
+		slog.Error("failed to get session", "err", err, "op", "saveVoiceTurn")
 		return
 	}
 
@@ -632,7 +632,7 @@ func (a *Assistant) saveVoiceTurn(ctx context.Context, userID int, sessionID, ro
 	}
 
 	if err := a.session.AppendEvent(ctx, getResp.Session, event); err != nil {
-		slog.Error("saveVoiceTurn: session.AppendEvent() error", "role", role, "err", err)
+		slog.Error("failed to append event", "role", role, "err", err, "op", "saveVoiceTurn")
 	}
 }
 
@@ -656,7 +656,7 @@ func (a *Assistant) saveTextImageTurn(ctx context.Context, userID int, sessionID
 		SessionID: sessionID,
 	})
 	if err != nil {
-		slog.Error("saveTextImageTurn: session.Get() error", "err", err)
+		slog.Error("failed to get session", "err", err, "op", "saveTextImageTurn")
 		return
 	}
 
@@ -673,7 +673,7 @@ func (a *Assistant) saveTextImageTurn(ctx context.Context, userID int, sessionID
 	}
 
 	if err := a.session.AppendEvent(ctx, getResp.Session, event); err != nil {
-		slog.Error("saveTextImageTurn: session.AppendEvent() error", "err", err)
+		slog.Error("failed to append event", "err", err, "op", "saveTextImageTurn")
 	}
 }
 

--- a/internal/app/aiguide/assistant/memory_api.go
+++ b/internal/app/aiguide/assistant/memory_api.go
@@ -94,14 +94,14 @@ func (a *Assistant) ListMemories(ctx *gin.Context) {
 
 	var total int64
 	if err := query.Count(&total).Error; err != nil {
-		slog.Error("query.Count() error", "err", err, "user_id", userID)
+		slog.Error("failed to count memories", "err", err, "user_id", userID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load memories"})
 		return
 	}
 
 	var memories []table.UserMemory
 	if err := query.Order("importance DESC, updated_at DESC, id DESC").Limit(limit).Offset(offset).Find(&memories).Error; err != nil {
-		slog.Error("query.Find() error", "err", err, "user_id", userID)
+		slog.Error("failed to query memories", "err", err, "user_id", userID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load memories"})
 		return
 	}
@@ -129,7 +129,7 @@ func (a *Assistant) CreateMemory(ctx *gin.Context) {
 
 	var req CreateMemoryRequest
 	if err := ctx.BindJSON(&req); err != nil {
-		slog.Error("ctx.BindJSON() error", "err", err)
+		slog.Error("failed to bind request body", "err", err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 		return
 	}
@@ -158,7 +158,7 @@ func (a *Assistant) CreateMemory(ctx *gin.Context) {
 		Importance: importance,
 	}
 	if err := a.db.Create(&memory).Error; err != nil {
-		slog.Error("db.Create() error", "err", err, "user_id", userID)
+		slog.Error("failed to create memory", "err", err, "user_id", userID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create memory"})
 		return
 	}
@@ -182,7 +182,7 @@ func (a *Assistant) UpdateMemory(ctx *gin.Context) {
 
 	var req UpdateMemoryRequest
 	if err := ctx.BindJSON(&req); err != nil {
-		slog.Error("ctx.BindJSON() error", "err", err)
+		slog.Error("failed to bind request body", "err", err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 		return
 	}
@@ -198,7 +198,7 @@ func (a *Assistant) UpdateMemory(ctx *gin.Context) {
 			ctx.JSON(http.StatusNotFound, gin.H{"error": "memory not found"})
 			return
 		}
-		slog.Error("db.First() error", "err", err, "user_id", userID, "memory_id", memoryID)
+		slog.Error("failed to find memory", "err", err, "user_id", userID, "memory_id", memoryID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update memory"})
 		return
 	}
@@ -229,7 +229,7 @@ func (a *Assistant) UpdateMemory(ctx *gin.Context) {
 	}
 
 	if err := a.db.Save(&memory).Error; err != nil {
-		slog.Error("db.Save() error", "err", err, "user_id", userID, "memory_id", memoryID)
+		slog.Error("failed to save memory", "err", err, "user_id", userID, "memory_id", memoryID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update memory"})
 		return
 	}
@@ -253,7 +253,7 @@ func (a *Assistant) DeleteMemory(ctx *gin.Context) {
 
 	result := a.db.Where("id = ? AND user_id = ?", memoryID, userID).Delete(&table.UserMemory{})
 	if result.Error != nil {
-		slog.Error("db.Delete() error", "err", result.Error, "user_id", userID, "memory_id", memoryID)
+		slog.Error("failed to delete memory", "err", result.Error, "user_id", userID, "memory_id", memoryID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete memory"})
 		return
 	}
@@ -286,7 +286,7 @@ func (a *Assistant) GetMemorySummary(ctx *gin.Context) {
 
 	var total int64
 	if err := a.db.Model(&table.UserMemory{}).Where("user_id = ?", userID).Count(&total).Error; err != nil {
-		slog.Error("db.Count() error", "err", err, "user_id", userID)
+		slog.Error("failed to count total memories", "err", err, "user_id", userID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load memory summary"})
 		return
 	}
@@ -297,7 +297,7 @@ func (a *Assistant) GetMemorySummary(ctx *gin.Context) {
 		Where("user_id = ?", userID).
 		Group("memory_type").
 		Scan(&rows).Error; err != nil {
-		slog.Error("db.Scan() error", "err", err, "user_id", userID)
+		slog.Error("failed to query memory type counts", "err", err, "user_id", userID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load memory summary"})
 		return
 	}
@@ -310,7 +310,7 @@ func (a *Assistant) GetMemorySummary(ctx *gin.Context) {
 	var lastUpdatedAt *time.Time
 	if err := a.db.Where("user_id = ?", userID).Order("updated_at DESC, id DESC").First(&latestMemory).Error; err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			slog.Error("db.First() error", "err", err, "user_id", userID)
+			slog.Error("failed to find latest memory", "err", err, "user_id", userID)
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load memory summary"})
 			return
 		}

--- a/internal/app/aiguide/assistant/pdf_message_parts.go
+++ b/internal/app/aiguide/assistant/pdf_message_parts.go
@@ -88,7 +88,7 @@ func appendUserUploadPart(
 
 	parsedUserID, err := strconv.Atoi(userID)
 	if err != nil {
-		slog.Error("strconv.Atoi() error", "user_id", userID, "err", err)
+		slog.Error("failed to parse user id", "user_id", userID, "err", err)
 		return nil, fmt.Errorf("invalid user_id: %w", err)
 	}
 

--- a/internal/app/aiguide/assistant/project.go
+++ b/internal/app/aiguide/assistant/project.go
@@ -34,7 +34,7 @@ func (a *Assistant) ListProjects(ctx *gin.Context) {
 
 	var projects []table.Project
 	if err := a.db.Where("user_id = ?", userID).Order("updated_at DESC, id DESC").Find(&projects).Error; err != nil {
-		slog.Error("db.Find() error", "err", err, "user_id", userID)
+		slog.Error("failed to query projects", "err", err, "user_id", userID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load projects"})
 		return
 	}
@@ -64,7 +64,7 @@ func (a *Assistant) CreateProject(ctx *gin.Context) {
 
 	var req CreateProjectRequest
 	if err := ctx.BindJSON(&req); err != nil {
-		slog.Error("ctx.BindJSON() error", "err", err)
+		slog.Error("failed to bind request body", "err", err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 		return
 	}
@@ -80,7 +80,7 @@ func (a *Assistant) CreateProject(ctx *gin.Context) {
 		ctx.JSON(http.StatusOK, ProjectInfo{ID: existing.ID, Name: existing.Name})
 		return
 	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
-		slog.Error("db.First() error", "err", err, "user_id", userID, "project_name", projectName)
+		slog.Error("failed to check existing project", "err", err, "user_id", userID, "project_name", projectName)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create project"})
 		return
 	}
@@ -90,7 +90,7 @@ func (a *Assistant) CreateProject(ctx *gin.Context) {
 		Name:   projectName,
 	}
 	if err := a.db.Create(&project).Error; err != nil {
-		slog.Error("db.Create() error", "err", err, "user_id", userID, "project_name", projectName)
+		slog.Error("failed to create project", "err", err, "user_id", userID, "project_name", projectName)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create project"})
 		return
 	}
@@ -131,18 +131,18 @@ func (a *Assistant) deleteProject(userID, projectID int) error {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return errProjectNotFound
 			}
-			slog.Error("tx.First() error", "err", err, "user_id", userID, "project_id", projectID)
-			return fmt.Errorf("tx.First() error: %w", err)
+			slog.Error("failed to find project for deletion", "err", err, "user_id", userID, "project_id", projectID)
+			return fmt.Errorf("failed to find project for deletion: %w", err)
 		}
 
 		if err := tx.Model(&table.SessionMeta{}).Where("project_id = ?", projectID).Update("project_id", 0).Error; err != nil {
-			slog.Error("tx.Model().Update() error", "err", err, "project_id", projectID)
-			return fmt.Errorf("tx.Model().Update() error: %w", err)
+			slog.Error("failed to unlink sessions from project", "err", err, "project_id", projectID)
+			return fmt.Errorf("failed to unlink sessions: %w", err)
 		}
 
 		if err := tx.Delete(&project).Error; err != nil {
-			slog.Error("tx.Delete() error", "err", err, "user_id", userID, "project_id", projectID)
-			return fmt.Errorf("tx.Delete() error: %w", err)
+			slog.Error("failed to delete project", "err", err, "user_id", userID, "project_id", projectID)
+			return fmt.Errorf("failed to delete project: %w", err)
 		}
 
 		return nil
@@ -169,7 +169,7 @@ func (a *Assistant) UpdateProject(ctx *gin.Context) {
 
 	var req UpdateProjectRequest
 	if err := ctx.BindJSON(&req); err != nil {
-		slog.Error("ctx.BindJSON() error", "err", err)
+		slog.Error("failed to bind request body", "err", err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 		return
 	}
@@ -199,8 +199,8 @@ func (a *Assistant) updateProjectName(userID, projectID int, projectName string)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, errProjectNotFound
 		}
-		slog.Error("db.First() error", "err", err, "user_id", userID, "project_id", projectID)
-		return nil, fmt.Errorf("db.First() error: %w", err)
+		slog.Error("failed to find project", "err", err, "user_id", userID, "project_id", projectID)
+		return nil, fmt.Errorf("failed to find project: %w", err)
 	}
 
 	var existing table.Project
@@ -208,14 +208,14 @@ func (a *Assistant) updateProjectName(userID, projectID int, projectName string)
 		project = existing
 		return &project, nil
 	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
-		slog.Error("db.First() error", "err", err, "user_id", userID, "project_name", projectName, "project_id", projectID)
-		return nil, fmt.Errorf("db.First() error: %w", err)
+		slog.Error("failed to check duplicate project name", "err", err, "user_id", userID, "project_name", projectName, "project_id", projectID)
+		return nil, fmt.Errorf("failed to check duplicate project name: %w", err)
 	}
 
 	project.Name = projectName
 	if err := a.db.Save(&project).Error; err != nil {
-		slog.Error("db.Save() error", "err", err, "user_id", userID, "project_id", projectID, "project_name", projectName)
-		return nil, fmt.Errorf("db.Save() error: %w", err)
+		slog.Error("failed to save project", "err", err, "user_id", userID, "project_id", projectID, "project_name", projectName)
+		return nil, fmt.Errorf("failed to save project: %w", err)
 	}
 
 	return &project, nil
@@ -238,7 +238,7 @@ func (a *Assistant) UpdateSessionProject(ctx *gin.Context) {
 
 	var req UpdateSessionProjectRequest
 	if err := ctx.BindJSON(&req); err != nil {
-		slog.Error("ctx.BindJSON() error", "err", err)
+		slog.Error("failed to bind request body", "err", err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 		return
 	}
@@ -258,7 +258,7 @@ func (a *Assistant) UpdateSessionProject(ctx *gin.Context) {
 		SessionID: sessionID,
 	}
 	if _, err := a.session.Get(ctx, getReq); err != nil {
-		slog.Error("session.Get() error", "err", err, "session_id", sessionID, "user_id", userID)
+		slog.Error("failed to get session", "err", err, "session_id", sessionID, "user_id", userID)
 		ctx.JSON(http.StatusNotFound, gin.H{"error": "session not found"})
 		return
 	}
@@ -284,8 +284,8 @@ func (a *Assistant) ensureProjectOwnership(userID int, projectID int) error {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return errProjectNotFound
 		}
-		slog.Error("db.First() error", "err", err, "user_id", userID, "project_id", projectID)
-		return fmt.Errorf("db.First() error: %w", err)
+		slog.Error("failed to verify project ownership", "err", err, "user_id", userID, "project_id", projectID)
+		return fmt.Errorf("failed to verify project ownership: %w", err)
 	}
 
 	return nil
@@ -295,8 +295,8 @@ func (a *Assistant) upsertSessionProjectMeta(sessionID string, projectID int) er
 	var meta table.SessionMeta
 	if err := a.db.Where("session_id = ?", sessionID).First(&meta).Error; err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			slog.Error("db.First() error", "err", err, "session_id", sessionID)
-			return fmt.Errorf("db.First() error: %w", err)
+			slog.Error("failed to find session meta", "err", err, "session_id", sessionID)
+			return fmt.Errorf("failed to find session meta: %w", err)
 		}
 
 		meta = table.SessionMeta{
@@ -306,8 +306,8 @@ func (a *Assistant) upsertSessionProjectMeta(sessionID string, projectID int) er
 			Version:   1,
 		}
 		if err := a.db.Create(&meta).Error; err != nil {
-			slog.Error("db.Create() error", "err", err, "session_id", sessionID)
-			return fmt.Errorf("db.Create() error: %w", err)
+			slog.Error("failed to create session meta", "err", err, "session_id", sessionID)
+			return fmt.Errorf("failed to create session meta: %w", err)
 		}
 		return nil
 	}
@@ -323,8 +323,8 @@ func (a *Assistant) upsertSessionProjectMeta(sessionID string, projectID int) er
 	}
 
 	if err := a.db.Model(&meta).Updates(updates).Error; err != nil {
-		slog.Error("db.Model().Updates() error", "err", err, "session_id", sessionID)
-		return fmt.Errorf("db.Model().Updates() error: %w", err)
+		slog.Error("failed to update session meta", "err", err, "session_id", sessionID)
+		return fmt.Errorf("failed to update session meta: %w", err)
 	}
 
 	return nil

--- a/internal/app/aiguide/assistant/runner.go
+++ b/internal/app/aiguide/assistant/runner.go
@@ -33,7 +33,7 @@ func (a *Assistant) createRunner() (*runner.Runner, error) {
 
 	assistantAgent, err := NewAssistantAgent(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("NewAssistantAgent() error, err = %w", err)
+		return nil, fmt.Errorf("failed to create assistant agent: %w", err)
 	}
 
 	runnerConfig := runner.Config{
@@ -43,8 +43,8 @@ func (a *Assistant) createRunner() (*runner.Runner, error) {
 	}
 	r, err := runner.New(runnerConfig)
 	if err != nil {
-		slog.Error("runner.New() error", "err", err)
-		return nil, fmt.Errorf("runner.New() error, err = %w", err)
+		slog.Error("failed to create runner", "err", err)
+		return nil, fmt.Errorf("failed to create runner: %w", err)
 	}
 
 	return r, nil
@@ -55,7 +55,7 @@ func (a *Assistant) createRunner() (*runner.Runner, error) {
 func (a *Assistant) createExecutorRunner() (*runner.Runner, error) {
 	assistantAgent, err := NewAssistantAgent(a.baseAgentConfig())
 	if err != nil {
-		return nil, fmt.Errorf("NewAssistantAgent() error, err = %w", err)
+		return nil, fmt.Errorf("failed to create assistant agent for executor: %w", err)
 	}
 
 	runnerConfig := runner.Config{
@@ -65,8 +65,8 @@ func (a *Assistant) createExecutorRunner() (*runner.Runner, error) {
 	}
 	r, err := runner.New(runnerConfig)
 	if err != nil {
-		slog.Error("runner.New() error for executor runner", "err", err)
-		return nil, fmt.Errorf("runner.New() error, err = %w", err)
+		slog.Error("failed to create executor runner", "err", err)
+		return nil, fmt.Errorf("failed to create executor runner: %w", err)
 	}
 
 	return r, nil

--- a/internal/app/aiguide/assistant/scheduled_task_api.go
+++ b/internal/app/aiguide/assistant/scheduled_task_api.go
@@ -50,7 +50,7 @@ func (a *Assistant) ListScheduledTasks(ctx *gin.Context) {
 
 	var tasks []table.ScheduledTask
 	if err := a.db.Where("user_id = ?", userID).Order("created_at DESC").Find(&tasks).Error; err != nil {
-		slog.Error("db.Find() error", "err", err, "user_id", userID)
+		slog.Error("failed to query scheduled tasks", "err", err, "user_id", userID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load scheduled tasks"})
 		return
 	}
@@ -82,7 +82,7 @@ func (a *Assistant) DeleteScheduledTask(ctx *gin.Context) {
 
 	result := a.db.Where("id = ? AND user_id = ?", taskID, userID).Delete(&table.ScheduledTask{})
 	if result.Error != nil {
-		slog.Error("db.Delete() error", "err", result.Error, "user_id", userID, "task_id", taskID)
+		slog.Error("failed to delete scheduled task", "err", result.Error, "user_id", userID, "task_id", taskID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete scheduled task"})
 		return
 	}
@@ -110,7 +110,7 @@ func (a *Assistant) UpdateScheduledTask(ctx *gin.Context) {
 
 	var req UpdateScheduledTaskRequest
 	if err := ctx.BindJSON(&req); err != nil {
-		slog.Error("ctx.BindJSON() error", "err", err)
+		slog.Error("failed to bind request body", "err", err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 		return
 	}
@@ -126,14 +126,14 @@ func (a *Assistant) UpdateScheduledTask(ctx *gin.Context) {
 			ctx.JSON(http.StatusNotFound, gin.H{"error": "scheduled task not found"})
 			return
 		}
-		slog.Error("db.First() error", "err", err, "user_id", userID, "task_id", taskID)
+		slog.Error("failed to find scheduled task", "err", err, "user_id", userID, "task_id", taskID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load scheduled task"})
 		return
 	}
 
 	task.Enabled = *req.Enabled
 	if err := a.db.Save(&task).Error; err != nil {
-		slog.Error("db.Save() error", "err", err, "user_id", userID, "task_id", taskID)
+		slog.Error("failed to save scheduled task", "err", err, "user_id", userID, "task_id", taskID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update scheduled task"})
 		return
 	}

--- a/internal/app/aiguide/assistant/scheduler.go
+++ b/internal/app/aiguide/assistant/scheduler.go
@@ -71,7 +71,6 @@ func (s *Scheduler) tick(ctx context.Context) {
 	}
 
 	for _, task := range tasks {
-		task := task // capture loop variable
 
 		// Pre-advance next_run_at (or disable for once-tasks) before
 		// dispatching. This prevents double-dispatch if the task takes
@@ -107,7 +106,7 @@ func (s *Scheduler) advanceNextRunAt(task table.ScheduledTask, now time.Time) er
 	}
 	nextRunAt, err := tools.CalculateNextRunAt(now, input)
 	if err != nil {
-		return fmt.Errorf("CalculateNextRunAt() error: %w", err)
+		return fmt.Errorf("failed to calculate next run time: %w", err)
 	}
 
 	return s.db.Model(&task).Update("next_run_at", nextRunAt).Error
@@ -141,7 +140,7 @@ func (s *Scheduler) dispatch(ctx context.Context, task table.ScheduledTask) erro
 		State:     map[string]any{},
 	}
 	if _, err := s.session.Create(taskCtx, createReq); err != nil {
-		return fmt.Errorf("session.Create() error: %w", err)
+		return fmt.Errorf("failed to create session for scheduled task: %w", err)
 	}
 
 	// Make session_id available in the context so tools that read it

--- a/internal/app/aiguide/assistant/session.go
+++ b/internal/app/aiguide/assistant/session.go
@@ -127,7 +127,7 @@ func (a *Assistant) ListSessions(ctx *gin.Context) {
 
 	listResp, err := a.session.List(ctx, listReq)
 	if err != nil {
-		slog.Error("session.List() error", "err", err)
+		slog.Error("failed to list sessions", "err", err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -289,7 +289,7 @@ func (a *Assistant) GetSessionHistory(ctx *gin.Context) {
 
 	getResp, err := a.session.Get(ctx, getReq)
 	if err != nil {
-		slog.Error("session.Get() error", "err", err)
+		slog.Error("failed to get session history", "err", err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -642,7 +642,7 @@ func (a *Assistant) CreateSession(ctx *gin.Context) {
 
 	var req CreateSessionRequest
 	if err := ctx.BindJSON(&req); err != nil {
-		slog.Error("ctx.BindJSON() error", "err", err)
+		slog.Error("failed to bind create session request", "err", err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 		return
 	}
@@ -667,7 +667,7 @@ func (a *Assistant) CreateSession(ctx *gin.Context) {
 	}
 
 	if _, err := a.session.Create(ctx, createReq); err != nil {
-		slog.Error("session.Create() error", "err", err)
+		slog.Error("failed to create session", "err", err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -713,7 +713,7 @@ func (a *Assistant) DeleteSession(ctx *gin.Context) {
 	}
 
 	if err := a.session.Delete(ctx, deleteReq); err != nil {
-		slog.Error("session.Delete() error", "err", err)
+		slog.Error("failed to delete session", "err", err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -731,7 +731,7 @@ func randomString(length int) string {
 	bytes := make([]byte, length/2+1) // hex encoding doubles the length
 	if _, err := rand.Read(bytes); err != nil {
 		// 降级到基于时间的方法（不应该发生）
-		slog.Error("crypto/rand.Read() failed", "err", err)
+		slog.Error("failed to generate random bytes", "err", err)
 		return time.Now().Format("150405999999")[:length]
 	}
 	return hex.EncodeToString(bytes)[:length]

--- a/internal/app/aiguide/assistant/session_edit.go
+++ b/internal/app/aiguide/assistant/session_edit.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -44,7 +45,7 @@ func (a *Assistant) EditSession(ctx *gin.Context) {
 
 	var req EditSessionRequest
 	if err := ctx.BindJSON(&req); err != nil {
-		slog.Error("ctx.BindJSON() error", "err", err)
+		slog.Error("failed to bind edit session request", "err", err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request", "code": "invalid_edit_payload"})
 		return
 	}
@@ -75,7 +76,7 @@ func (a *Assistant) EditSession(ctx *gin.Context) {
 
 	getResp, err := a.session.Get(ctx, getReq)
 	if err != nil {
-		slog.Error("session.Get() error", "err", err, "session_id", sessionID, "user_id", req.UserID)
+		slog.Error("failed to load session for editing", "err", err, "session_id", sessionID, "user_id", req.UserID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load session"})
 		return
 	}
@@ -100,14 +101,14 @@ func (a *Assistant) EditSession(ctx *gin.Context) {
 	}
 	createResp, err := a.session.Create(ctx, createReq)
 	if err != nil {
-		slog.Error("session.Create() error", "err", err, "session_id", newSessionID, "user_id", req.UserID)
+		slog.Error("failed to create edited session", "err", err, "session_id", newSessionID, "user_id", req.UserID)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create edited session"})
 		return
 	}
 
 	for _, event := range eventsToCopy {
 		if err := a.session.AppendEvent(ctx, createResp.Session, event); err != nil {
-			slog.Error("session.AppendEvent() error", "err", err, "session_id", newSessionID)
+			slog.Error("failed to replay session event", "err", err, "session_id", newSessionID)
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to replay session history"})
 			return
 		}
@@ -206,19 +207,15 @@ func cloneContent(content *genai.Content) *genai.Content {
 }
 
 func cloneSessionState(state session.State) map[string]any {
-	clonedState := map[string]any{}
-	for key, value := range state.All() {
-		clonedState[key] = value
-	}
-	return clonedState
+	return maps.Collect(state.All())
 }
 
 func (a *Assistant) createEditedSessionMeta(parentSessionID, newSessionID, messageID string) (string, int, error) {
 	var parentMeta table.SessionMeta
 	if err := a.db.Where("session_id = ?", parentSessionID).First(&parentMeta).Error; err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			slog.Error("db.First() error", "err", err, "session_id", parentSessionID)
-			return "", 0, fmt.Errorf("db.First() error: %w", err)
+			slog.Error("failed to find session meta", "err", err, "session_id", parentSessionID)
+			return "", 0, fmt.Errorf("failed to find session meta: %w", err)
 		}
 	}
 
@@ -238,16 +235,16 @@ func (a *Assistant) createEditedSessionMeta(parentSessionID, newSessionID, messa
 			Version:   parentVersion,
 		}
 		if err := a.db.Create(&parentMeta).Error; err != nil {
-			slog.Error("db.Create() error", "err", err, "session_id", parentSessionID)
-			return "", 0, fmt.Errorf("db.Create() error: %w", err)
+			slog.Error("failed to create parent session meta", "err", err, "session_id", parentSessionID)
+			return "", 0, fmt.Errorf("failed to create parent session meta: %w", err)
 		}
 	} else if parentMeta.ThreadID == "" || parentMeta.Version == 0 {
 		if err := a.db.Model(&parentMeta).Updates(map[string]any{
 			"thread_id": threadID,
 			"version":   parentVersion,
 		}).Error; err != nil {
-			slog.Error("db.Model().Updates() error", "err", err, "session_id", parentSessionID)
-			return "", 0, fmt.Errorf("db.Model().Updates() error: %w", err)
+			slog.Error("failed to update session meta", "err", err, "session_id", parentSessionID)
+			return "", 0, fmt.Errorf("failed to update session meta: %w", err)
 		}
 	}
 
@@ -262,8 +259,8 @@ func (a *Assistant) createEditedSessionMeta(parentSessionID, newSessionID, messa
 		EditedFromMessageID: messageID,
 	}
 	if err := a.db.Create(&newMeta).Error; err != nil {
-		slog.Error("db.Create() error", "err", err, "session_id", newSessionID)
-		return "", 0, fmt.Errorf("db.Create() error: %w", err)
+		slog.Error("failed to create new session meta", "err", err, "session_id", newSessionID)
+		return "", 0, fmt.Errorf("failed to create new session meta: %w", err)
 	}
 
 	return threadID, newVersion, nil

--- a/internal/app/aiguide/assistant/share.go
+++ b/internal/app/aiguide/assistant/share.go
@@ -56,7 +56,7 @@ func (a *Assistant) CreateShare(ctx *gin.Context) {
 
 	var req CreateShareRequest
 	if err := ctx.BindJSON(&req); err != nil {
-		slog.Error("ctx.BindJSON() error", "err", err)
+		slog.Error("failed to bind create share request", "err", err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 		return
 	}
@@ -77,7 +77,7 @@ func (a *Assistant) CreateShare(ctx *gin.Context) {
 
 	getResp, err := a.session.Get(ctx, getReq)
 	if err != nil {
-		slog.Error("session.Get() error", "err", err)
+		slog.Error("failed to get session for sharing", "err", err)
 		ctx.JSON(http.StatusNotFound, gin.H{"error": "session not found or access denied"})
 		return
 	}
@@ -103,7 +103,7 @@ func (a *Assistant) CreateShare(ctx *gin.Context) {
 	}
 
 	if err := a.db.Create(&sharedConv).Error; err != nil {
-		slog.Error("a.db.Create() error", "err", err)
+		slog.Error("failed to create share record", "err", err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create share link"})
 		return
 	}
@@ -133,7 +133,7 @@ func (a *Assistant) GetSharedConversation(ctx *gin.Context) {
 	// Look up the shared conversation
 	var sharedConv table.SharedConversation
 	if err := a.db.Where("share_id = ?", shareID).First(&sharedConv).Error; err != nil {
-		slog.Error("a.db.Where().First() error", "share_id", shareID, "err", err)
+		slog.Error("failed to find shared conversation", "share_id", shareID, "err", err)
 		ctx.JSON(http.StatusNotFound, gin.H{"error": "shared conversation not found"})
 		return
 	}
@@ -161,7 +161,7 @@ func (a *Assistant) GetSharedConversation(ctx *gin.Context) {
 
 	getResp, err := a.session.Get(ctx, getReq)
 	if err != nil {
-		slog.Error("session.Get() error", "err", err)
+		slog.Error("failed to get shared session data", "err", err)
 		ctx.JSON(http.StatusNotFound, gin.H{"error": "conversation not found"})
 		return
 	}
@@ -173,7 +173,7 @@ func (a *Assistant) GetSharedConversation(ctx *gin.Context) {
 	if err := a.db.Where("session_id = ?", sharedConv.SessionID).First(&meta).Error; err == nil {
 		title = meta.Title
 	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
-		slog.Error("a.db.Where().First() session meta error", "session_id", sharedConv.SessionID, "err", err)
+		slog.Error("failed to query session meta for share", "session_id", sharedConv.SessionID, "err", err)
 	}
 
 	// Build message events from session
@@ -212,14 +212,14 @@ func (a *Assistant) DeleteShare(ctx *gin.Context) {
 	// Find the shared conversation and verify ownership
 	var sharedConv table.SharedConversation
 	if err := a.db.Where("share_id = ? AND user_id = ?", shareID, userID).First(&sharedConv).Error; err != nil {
-		slog.Error("a.db.Where().First() error", "share_id", shareID, "user_id", userID, "err", err)
+		slog.Error("failed to find share for deletion", "share_id", shareID, "user_id", userID, "err", err)
 		ctx.JSON(http.StatusNotFound, gin.H{"error": "shared conversation not found or access denied"})
 		return
 	}
 
 	// Delete the share
 	if err := a.db.Delete(&sharedConv).Error; err != nil {
-		slog.Error("a.db.Delete() error", "err", err)
+		slog.Error("failed to delete share record", "err", err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete share link"})
 		return
 	}
@@ -247,7 +247,7 @@ func (a *Assistant) ListShares(ctx *gin.Context) {
 	}
 
 	if err := query.Order("created_at DESC").Find(&shares).Error; err != nil {
-		slog.Error("query.Find() error", "err", err)
+		slog.Error("failed to query share records", "err", err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list share links"})
 		return
 	}

--- a/internal/app/aiguide/assistant/sse.go
+++ b/internal/app/aiguide/assistant/sse.go
@@ -73,7 +73,7 @@ var imageMimeAliases = map[string]string{
 func (a *Assistant) Chat(ctx *gin.Context) {
 	var req ChatRequest
 	if err := ctx.BindJSON(&req); err != nil {
-		slog.Error("ctx.BindJSON() error", "err", err)
+		slog.Error("failed to bind chat request", "err", err)
 		ctx.JSON(400, gin.H{"error": "invalid request"})
 		return
 	}
@@ -91,7 +91,7 @@ func (a *Assistant) Chat(ctx *gin.Context) {
 
 	parts, err := buildUserMessageParts(ctx, a.db, a.fileStore, userID, sessionID, messageText, req.Images, req.FileNames, true)
 	if err != nil {
-		slog.Error("buildUserMessageParts() error", "err", err)
+		slog.Error("failed to build user message parts", "err", err)
 		ctx.JSON(400, gin.H{"error": err.Error()})
 		return
 	}
@@ -207,7 +207,7 @@ func parseDataURI(dataURI string) ([]byte, string, error) {
 
 	decoded, err := base64.StdEncoding.DecodeString(payload)
 	if err != nil {
-		slog.Error("base64.StdEncoding.DecodeString() error", "err", err)
+		slog.Error("failed to decode base64 data", "err", err)
 		return nil, "", fmt.Errorf("invalid base64 data: %w", err)
 	}
 	if len(decoded) == 0 {
@@ -243,8 +243,8 @@ func (a *Assistant) ensureSession(ctx *gin.Context, userID, sessionID string) (i
 
 	if _, err := a.session.Get(ctx, sessionGetReq); err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			slog.Error("session.Get() error", "err", err)
-			return false, fmt.Errorf("session.Get() error, err = %w", err)
+			slog.Error("failed to get session", "err", err)
+			return false, fmt.Errorf("failed to get session: %w", err)
 		}
 
 		// Session 不存在，创建新的 session
@@ -256,15 +256,15 @@ func (a *Assistant) ensureSession(ctx *gin.Context, userID, sessionID string) (i
 		}
 
 		if _, err := a.session.Create(ctx, sessionCreateReq); err != nil {
-			slog.Error("session.Create() error", "err", err)
-			return false, fmt.Errorf("session.Create() error, err = %w", err)
+			slog.Error("failed to create new session", "err", err)
+			return false, fmt.Errorf("failed to create session: %w", err)
 		}
 
 		// 创建后验证 session 是否成功保存
 		// 这有助于捕捉数据库同步或创建失败的情况
 		if _, err := a.session.Get(ctx, sessionGetReq); err != nil {
-			slog.Error("session.Get() after create error", "err", err, "appName", constant.AppNameAssistant.String(), "userID", userID, "sessionID", sessionID)
-			return false, fmt.Errorf("session.Get() after create error, err = %w", err)
+			slog.Error("failed to verify session after creation", "err", err, "appName", constant.AppNameAssistant.String(), "userID", userID, "sessionID", sessionID)
+			return false, fmt.Errorf("failed to verify session after creation: %w", err)
 		}
 
 		return true, nil
@@ -347,7 +347,7 @@ func (a *Assistant) streamAgentEvents(
 			}
 
 			// 发送错误事件，包含详细的错误信息
-			slog.Error("runner.Run() error", "err", err, "userID", userID, "sessionID", sessionID)
+			slog.Error("failed to run agent", "err", err, "userID", userID, "sessionID", sessionID)
 			errorMsg := err.Error()
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				errorMsg = "Session 不存在或已被删除，请重新创建"
@@ -544,8 +544,8 @@ var memoryTypeLabel = map[constant.MemoryType]string{
 func (a *Assistant) fetchUserMemories(userID int) (string, error) {
 	var memories []table.UserMemory
 	if err := a.db.Where("user_id = ?", userID).Order("importance DESC, updated_at DESC").Find(&memories).Error; err != nil {
-		slog.Error("db.Find() error querying user memories", "err", err, "userID", userID)
-		return "", fmt.Errorf("db.Find() error: %w", err)
+		slog.Error("failed to query user memories", "err", err, "userID", userID)
+		return "", fmt.Errorf("failed to query user memories: %w", err)
 	}
 
 	if len(memories) == 0 {
@@ -560,7 +560,7 @@ func (a *Assistant) fetchUserMemories(userID int) (string, error) {
 		if label == "" {
 			label = string(mem.MemoryType)
 		}
-		sb.WriteString(fmt.Sprintf("- [%s] %s\n", label, mem.Content))
+		fmt.Fprintf(&sb, "- [%s] %s\n", label, mem.Content)
 	}
 	sb.WriteString("</user_context>\n")
 
@@ -588,8 +588,8 @@ func (a *Assistant) generateTitle(ctx context.Context, sessionID, firstMessage s
 			return nil
 		}
 	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
-		slog.Error("db.First() error", "err", err, "session_id", sessionID)
-		return fmt.Errorf("db.First() error, err = %w", err)
+		slog.Error("failed to query session meta for title", "err", err, "session_id", sessionID)
+		return fmt.Errorf("failed to query session meta for title: %w", err)
 	}
 
 	// 2. 调用 LLM 生成标题
@@ -609,8 +609,8 @@ func (a *Assistant) generateTitle(ctx context.Context, sessionID, firstMessage s
 	generatedTitle := ""
 	for resp, err := range a.model.GenerateContent(ctx, req, false) {
 		if err != nil {
-			slog.Error("a.model.GenerateContent() error", "err", err)
-			return fmt.Errorf("a.model.GenerateContent() error, err = %w", err)
+			slog.Error("failed to generate title content", "err", err)
+			return fmt.Errorf("failed to generate title content: %w", err)
 		}
 
 		// Check response content
@@ -646,8 +646,8 @@ func (a *Assistant) generateTitle(ctx context.Context, sessionID, firstMessage s
 	meta.Title = generatedTitle
 
 	if err := a.db.Save(&meta).Error; err != nil {
-		slog.Error("db.Save() error", "err", err)
-		return fmt.Errorf("db.Save() error, err = %w", err)
+		slog.Error("failed to save session title", "err", err)
+		return fmt.Errorf("failed to save session title: %w", err)
 	}
 
 	return nil

--- a/internal/app/aiguide/assistant/tts_api.go
+++ b/internal/app/aiguide/assistant/tts_api.go
@@ -45,7 +45,7 @@ func (a *Assistant) TextToSpeechStream(ctx *gin.Context) {
 	// 1. Authenticate
 	userID, ok := getContextUserID(ctx)
 	if !ok || userID <= 0 {
-		slog.Error("TextToSpeechStream: invalid or missing user_id in context")
+		slog.Error("invalid or missing user_id in context")
 		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
@@ -53,7 +53,7 @@ func (a *Assistant) TextToSpeechStream(ctx *gin.Context) {
 	// 2. Parse and validate request
 	var req TTSRequest
 	if err := ctx.BindJSON(&req); err != nil {
-		slog.Error("TextToSpeechStream: ctx.BindJSON() error", "err", err)
+		slog.Error("failed to bind request", "err", err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
 		return
 	}
@@ -103,7 +103,7 @@ func (a *Assistant) TextToSpeechStream(ctx *gin.Context) {
 
 		wavData, err := a.generateTTSChunk(ctx, chunk, req.VoiceName)
 		if err != nil {
-			slog.Error("TextToSpeechStream: generateTTSChunk error", "chunk", i, "err", err)
+			slog.Error("generateTTSChunk error", "chunk", i, "err", err)
 			ctx.SSEvent("error", gin.H{"error": fmt.Sprintf("failed to generate chunk %d: %s", i, err.Error())})
 			ctx.Writer.Flush()
 			return
@@ -150,7 +150,7 @@ func (a *Assistant) generateTTSChunk(ctx *gin.Context, text, voiceName string) (
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("genaiClient.Models.GenerateContent() error: %w", err)
+		return nil, fmt.Errorf("failed to generate TTS content: %w", err)
 	}
 
 	if len(ttsResp.Candidates) == 0 || ttsResp.Candidates[0].Content == nil {
@@ -252,7 +252,7 @@ func pcmToWAV(raw []byte, mimeType string) []byte {
 	sampleRate := uint32(24000)
 	numChannels := uint16(1)
 
-	for _, param := range strings.Split(mimeType, ";") {
+	for param := range strings.SplitSeq(mimeType, ";") {
 		param = strings.TrimSpace(param)
 		if v, ok := strings.CutPrefix(param, "rate="); ok {
 			if n, err := strconv.ParseUint(strings.TrimSpace(v), 10, 32); err == nil {

--- a/internal/app/aiguide/avatar.go
+++ b/internal/app/aiguide/avatar.go
@@ -39,14 +39,14 @@ func (a *AIGuide) GetAvatar(c *gin.Context) {
 	userIDStr := c.Param("userId")
 	userID, err := strconv.Atoi(userIDStr)
 	if err != nil {
-		slog.Error("strconv.Atoi() error", "err", err)
+		slog.Error("failed to parse user id", "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
 		return
 	}
 
 	var user table.User
 	if err := a.db.Where("id = ?", userID).First(&user).Error; err != nil {
-		slog.Error("db.First() error", "err", err)
+		slog.Error("failed to find user for avatar", "err", err)
 		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
 		return
 	}
@@ -93,7 +93,7 @@ func downloadAvatar(urlStr string) ([]byte, string, error) {
 	// Validate URL scheme to prevent SSRF attacks
 	parsedURL, err := url.Parse(urlStr)
 	if err != nil {
-		slog.Error("url.Parse() error", "url", urlStr, "err", err)
+		slog.Error("failed to parse avatar url", "url", urlStr, "err", err)
 		return nil, "", fmt.Errorf("invalid URL: %w", err)
 	}
 	if parsedURL.Scheme != "https" {
@@ -108,7 +108,7 @@ func downloadAvatar(urlStr string) ([]byte, string, error) {
 	// Create HTTP request
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
 	if err != nil {
-		slog.Error("http.NewRequestWithContext() error", "url", urlStr, "err", err)
+		slog.Error("failed to create avatar download request", "url", urlStr, "err", err)
 		return nil, "", fmt.Errorf("failed to create request: %w", err)
 	}
 
@@ -116,7 +116,7 @@ func downloadAvatar(urlStr string) ([]byte, string, error) {
 	client := http.DefaultClient
 	resp, err := client.Do(req)
 	if err != nil {
-		slog.Error("http.DefaultClient.Do() error", "url", urlStr, "err", err)
+		slog.Error("failed to download avatar", "url", urlStr, "err", err)
 		return nil, "", fmt.Errorf("failed to download avatar: %w", err)
 	}
 	defer resp.Body.Close()
@@ -156,7 +156,7 @@ func downloadAvatar(urlStr string) ([]byte, string, error) {
 	// Limit reading to MaxAvatarSizeBytes+1 to detect oversized responses
 	limitedReader := io.LimitReader(resp.Body, MaxAvatarSizeBytes+1)
 	if _, err := io.Copy(&buf, limitedReader); err != nil {
-		slog.Error("io.Copy() error", "err", err)
+		slog.Error("failed to read avatar response body", "err", err)
 		return nil, "", fmt.Errorf("failed to read avatar data: %w", err)
 	}
 

--- a/internal/app/aiguide/calendar_config.go
+++ b/internal/app/aiguide/calendar_config.go
@@ -31,7 +31,7 @@ func (a *AIGuide) GetCalendarStatus(c *gin.Context) {
 		Where("id = ?", userID).
 		First(&row).Error
 	if err != nil {
-		slog.Error("db.First() error", "err", err)
+		slog.Error("failed to query user calendar status", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get user"})
 		return
 	}
@@ -51,7 +51,7 @@ func (a *AIGuide) RevokeCalendarAccess(c *gin.Context) {
 	}
 
 	if err := a.db.Model(&table.User{}).Where("id = ?", userID).Update("google_oauth_refresh_token", "").Error; err != nil {
-		slog.Error("db.Update() error", "err", err)
+		slog.Error("failed to revoke calendar access", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to revoke access"})
 		return
 	}

--- a/internal/app/aiguide/login.go
+++ b/internal/app/aiguide/login.go
@@ -149,8 +149,8 @@ func saveUser(db *gorm.DB, user *auth.GoogleUser, refreshToken string) (*table.U
 	var u table.User
 	if err := db.Where("google_user_id = ?", user.ID).First(&u).Error; err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			slog.Error("db.First() error", "err", err)
-			return nil, fmt.Errorf("db.First() error, err = %w", err)
+			slog.Error("failed to find user by google id", "err", err)
+			return nil, fmt.Errorf("failed to find user by google id: %w", err)
 		}
 
 		// Download avatar image
@@ -171,8 +171,8 @@ func saveUser(db *gorm.DB, user *auth.GoogleUser, refreshToken string) (*table.U
 		}
 
 		if err := db.Create(&u).Error; err != nil {
-			slog.Error("db.Create() error", "err", err)
-			return nil, fmt.Errorf("db.Create() error, err = %w", err)
+			slog.Error("failed to create user record", "err", err)
+			return nil, fmt.Errorf("failed to create user record: %w", err)
 		}
 	} else {
 		// Update existing user info with only the fields that may have changed.
@@ -203,8 +203,8 @@ func saveUser(db *gorm.DB, user *auth.GoogleUser, refreshToken string) (*table.U
 		}
 
 		if err := db.Model(&u).Updates(updates).Error; err != nil {
-			slog.Error("db.Model().Updates() error", "err", err)
-			return nil, fmt.Errorf("db.Model().Updates() error: %w", err)
+			slog.Error("failed to update user record", "err", err)
+			return nil, fmt.Errorf("failed to update user record: %w", err)
 		}
 	}
 

--- a/internal/app/aiguide/migration/migration.go
+++ b/internal/app/aiguide/migration/migration.go
@@ -21,8 +21,8 @@ func New(db *gorm.DB) *Migrator {
 func (m *Migrator) Run() error {
 	models := table.GetAllModels()
 	if err := m.db.AutoMigrate(models...); err != nil {
-		slog.Error("m.db.AutoMigrate() error", "err", err)
-		return fmt.Errorf("m.db.AutoMigrate() error, err = %w", err)
+		slog.Error("failed to run database auto migration", "err", err)
+		return fmt.Errorf("failed to run database auto migration: %w", err)
 	}
 	return nil
 }

--- a/internal/app/aiguide/setting/email_server_config.go
+++ b/internal/app/aiguide/setting/email_server_config.go
@@ -40,7 +40,7 @@ type EmailServerConfigResponse struct {
 func (s *Setting) CreateEmailServerConfig(c *gin.Context) {
 	var req EmailServerConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		slog.Error("c.ShouldBindJSON() error", "err", err)
+		slog.Error("failed to bind email server config request", "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "请求参数错误: " + err.Error()})
 		return
 	}
@@ -55,7 +55,7 @@ func (s *Setting) CreateEmailServerConfig(c *gin.Context) {
 	// 查找用户
 	var user table.User
 	if err := s.db.Where("id = ?", userID).First(&user).Error; err != nil {
-		slog.Error("db.First() error", "err", err)
+		slog.Error("failed to find user", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "用户不存在"})
 		return
 	}
@@ -77,7 +77,7 @@ func (s *Setting) CreateEmailServerConfig(c *gin.Context) {
 	}
 
 	if err := s.db.Create(&config).Error; err != nil {
-		slog.Error("db.Create() error", "err", err)
+		slog.Error("failed to create email server config", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "创建配置失败: " + err.Error()})
 		return
 	}
@@ -110,14 +110,14 @@ func (s *Setting) ListEmailServerConfigs(c *gin.Context) {
 	// 查找用户
 	var user table.User
 	if err := s.db.Where("id = ?", userID).First(&user).Error; err != nil {
-		slog.Error("db.First() error", "err", err)
+		slog.Error("failed to find user", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "用户不存在"})
 		return
 	}
 
 	var configs []table.EmailServerConfig
 	if err := s.db.Where("user_id = ?", user.ID).Order("is_default DESC, created_at DESC").Find(&configs).Error; err != nil {
-		slog.Error("db.Find() error", "err", err)
+		slog.Error("failed to query email server configs", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "查询配置失败: " + err.Error()})
 		return
 	}
@@ -155,21 +155,21 @@ func (s *Setting) GetEmailServerConfig(c *gin.Context) {
 	// 查找用户
 	var user table.User
 	if err := s.db.Where("id = ?", userID).First(&user).Error; err != nil {
-		slog.Error("db.First() error", "err", err)
+		slog.Error("failed to find user", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "用户不存在"})
 		return
 	}
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		slog.Error("strconv.Atoi() error", "id", c.Param("id"), "err", err)
+		slog.Error("failed to parse config id", "id", c.Param("id"), "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的ID"})
 		return
 	}
 
 	var config table.EmailServerConfig
 	if err := s.db.Where("id = ? AND user_id = ?", id, user.ID).First(&config).Error; err != nil {
-		slog.Error("db.First() error", "config_id", id, "user_id", user.ID, "err", err)
+		slog.Error("failed to find email server config", "config_id", id, "user_id", user.ID, "err", err)
 		c.JSON(http.StatusNotFound, gin.H{"error": "配置不存在"})
 		return
 	}
@@ -194,7 +194,7 @@ func (s *Setting) GetEmailServerConfig(c *gin.Context) {
 func (s *Setting) UpdateEmailServerConfig(c *gin.Context) {
 	var req EmailServerConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		slog.Error("c.ShouldBindJSON() error", "err", err)
+		slog.Error("failed to bind update email config request", "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "请求参数错误: " + err.Error()})
 		return
 	}
@@ -209,21 +209,21 @@ func (s *Setting) UpdateEmailServerConfig(c *gin.Context) {
 	// 查找用户
 	var user table.User
 	if err := s.db.Where("id = ?", userID).First(&user).Error; err != nil {
-		slog.Error("s.db.Where().First() error in UpdateEmailServerConfig", "userID", userID, "err", err)
+		slog.Error("failed to find user for email config update", "userID", userID, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "用户不存在"})
 		return
 	}
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		slog.Error("strconv.Atoi() error in UpdateEmailServerConfig", "id", c.Param("id"), "err", err)
+		slog.Error("failed to parse config id for update", "id", c.Param("id"), "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的ID"})
 		return
 	}
 
 	var config table.EmailServerConfig
 	if err := s.db.Where("id = ? AND user_id = ?", id, user.ID).First(&config).Error; err != nil {
-		slog.Error("s.db.Where().First() error in UpdateEmailServerConfig", "id", id, "userID", user.ID, "err", err)
+		slog.Error("failed to find email config for update", "id", id, "userID", user.ID, "err", err)
 		c.JSON(http.StatusNotFound, gin.H{"error": "配置不存在"})
 		return
 	}
@@ -233,7 +233,7 @@ func (s *Setting) UpdateEmailServerConfig(c *gin.Context) {
 		if err := s.db.Model(&table.EmailServerConfig{}).
 			Where("user_id = ? AND id != ?", user.ID, id).
 			Update("is_default", false).Error; err != nil {
-			slog.Error("s.db.Model().Where().Update() error in UpdateEmailServerConfig", "userID", user.ID, "id", id, "err", err)
+			slog.Error("failed to clear default email config", "userID", user.ID, "id", id, "err", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "更新默认配置失败"})
 			return
 		}
@@ -257,7 +257,7 @@ func (s *Setting) UpdateEmailServerConfig(c *gin.Context) {
 	config.IsDefault = req.IsDefault
 
 	if err := s.db.Save(&config).Error; err != nil {
-		slog.Error("s.db.Save() error in UpdateEmailServerConfig", "configID", config.ID, "err", err)
+		slog.Error("failed to save email server config", "configID", config.ID, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "更新配置失败: " + err.Error()})
 		return
 	}
@@ -290,21 +290,21 @@ func (s *Setting) DeleteEmailServerConfig(c *gin.Context) {
 	// 查找用户
 	var user table.User
 	if err := s.db.Where("id = ?", userID).First(&user).Error; err != nil {
-		slog.Error("s.db.Where().First() error in DeleteEmailServerConfig", "userID", userID, "err", err)
+		slog.Error("failed to find user for email config deletion", "userID", userID, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "用户不存在"})
 		return
 	}
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		slog.Error("strconv.Atoi() error in DeleteEmailServerConfig", "id", c.Param("id"), "err", err)
+		slog.Error("failed to parse config id for deletion", "id", c.Param("id"), "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的ID"})
 		return
 	}
 
 	result := s.db.Where("id = ? AND user_id = ?", id, user.ID).Delete(&table.EmailServerConfig{})
 	if result.Error != nil {
-		slog.Error("s.db.Where().Delete() error", "id", id, "userID", user.ID, "err", result.Error)
+		slog.Error("failed to delete email server config", "id", id, "userID", user.ID, "err", result.Error)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "删除配置失败: " + result.Error.Error()})
 		return
 	}

--- a/internal/app/aiguide/setting/ssh_server_config.go
+++ b/internal/app/aiguide/setting/ssh_server_config.go
@@ -65,7 +65,7 @@ func toSSHResponse(cfg table.SSHServerConfig) SSHServerConfigResponse {
 func (s *Setting) CreateSSHServerConfig(c *gin.Context) {
 	var req SSHServerConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		slog.Error("c.ShouldBindJSON() error", "err", err)
+		slog.Error("failed to bind create ssh config request", "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request: " + err.Error()})
 		return
 	}
@@ -100,7 +100,7 @@ func (s *Setting) CreateSSHServerConfig(c *gin.Context) {
 	}
 
 	if err := s.db.Create(&cfg).Error; err != nil {
-		slog.Error("db.Create() error in CreateSSHServerConfig", "err", err)
+		slog.Error("failed to create ssh server config", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create config: " + err.Error()})
 		return
 	}
@@ -119,7 +119,7 @@ func (s *Setting) ListSSHServerConfigs(c *gin.Context) {
 
 	var configs []table.SSHServerConfig
 	if err := s.db.Where("user_id = ?", userID).Order("is_default DESC, created_at DESC").Find(&configs).Error; err != nil {
-		slog.Error("db.Find() error in ListSSHServerConfigs", "user_id", userID, "err", err)
+		slog.Error("failed to query ssh server configs", "user_id", userID, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list configs: " + err.Error()})
 		return
 	}
@@ -143,14 +143,14 @@ func (s *Setting) GetSSHServerConfig(c *gin.Context) {
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		slog.Error("strconv.Atoi() error in GetSSHServerConfig", "id", c.Param("id"), "err", err)
+		slog.Error("failed to parse ssh config id", "id", c.Param("id"), "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
 
 	var cfg table.SSHServerConfig
 	if err := s.db.Where("id = ? AND user_id = ?", id, userID).First(&cfg).Error; err != nil {
-		slog.Error("db.First() error in GetSSHServerConfig", "config_id", id, "user_id", userID, "err", err)
+		slog.Error("failed to find ssh server config", "config_id", id, "user_id", userID, "err", err)
 		c.JSON(http.StatusNotFound, gin.H{"error": "config not found"})
 		return
 	}
@@ -162,7 +162,7 @@ func (s *Setting) GetSSHServerConfig(c *gin.Context) {
 func (s *Setting) UpdateSSHServerConfig(c *gin.Context) {
 	var req SSHServerConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		slog.Error("c.ShouldBindJSON() error in UpdateSSHServerConfig", "err", err)
+		slog.Error("failed to bind update ssh config request", "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request: " + err.Error()})
 		return
 	}
@@ -176,14 +176,14 @@ func (s *Setting) UpdateSSHServerConfig(c *gin.Context) {
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		slog.Error("strconv.Atoi() error in UpdateSSHServerConfig", "id", c.Param("id"), "err", err)
+		slog.Error("failed to parse ssh config id for update", "id", c.Param("id"), "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
 
 	var cfg table.SSHServerConfig
 	if err := s.db.Where("id = ? AND user_id = ?", id, userID).First(&cfg).Error; err != nil {
-		slog.Error("db.First() error in UpdateSSHServerConfig", "config_id", id, "user_id", userID, "err", err)
+		slog.Error("failed to find ssh config for update", "config_id", id, "user_id", userID, "err", err)
 		c.JSON(http.StatusNotFound, gin.H{"error": "config not found"})
 		return
 	}
@@ -193,7 +193,7 @@ func (s *Setting) UpdateSSHServerConfig(c *gin.Context) {
 		if err := s.db.Model(&table.SSHServerConfig{}).
 			Where("user_id = ? AND id != ?", userID, id).
 			Update("is_default", false).Error; err != nil {
-			slog.Error("db.Update() error clearing is_default in UpdateSSHServerConfig", "user_id", userID, "id", id, "err", err)
+			slog.Error("failed to clear default ssh config", "user_id", userID, "id", id, "err", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update default config"})
 			return
 		}
@@ -223,7 +223,7 @@ func (s *Setting) UpdateSSHServerConfig(c *gin.Context) {
 	cfg.IsDefault = req.IsDefault
 
 	if err := s.db.Save(&cfg).Error; err != nil {
-		slog.Error("db.Save() error in UpdateSSHServerConfig", "config_id", cfg.ID, "err", err)
+		slog.Error("failed to save ssh server config", "config_id", cfg.ID, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update config: " + err.Error()})
 		return
 	}
@@ -242,14 +242,14 @@ func (s *Setting) DeleteSSHServerConfig(c *gin.Context) {
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		slog.Error("strconv.Atoi() error in DeleteSSHServerConfig", "id", c.Param("id"), "err", err)
+		slog.Error("failed to parse ssh config id for deletion", "id", c.Param("id"), "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
 
 	result := s.db.Where("id = ? AND user_id = ?", id, userID).Delete(&table.SSHServerConfig{})
 	if result.Error != nil {
-		slog.Error("db.Delete() error in DeleteSSHServerConfig", "id", id, "user_id", userID, "err", result.Error)
+		slog.Error("failed to delete ssh server config", "id", id, "user_id", userID, "err", result.Error)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete config: " + result.Error.Error()})
 		return
 	}

--- a/internal/app/aiguide/user.go
+++ b/internal/app/aiguide/user.go
@@ -21,7 +21,7 @@ func (a *AIGuide) GetUser(c *gin.Context) {
 
 	var user table.User
 	if err := a.db.Where("id = ?", userID).First(&user).Error; err != nil {
-		slog.Error("db.First() error", "err", err)
+		slog.Error("failed to find user", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"err": err})
 		return
 	}

--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -107,7 +107,7 @@ func (s *AuthService) GetGoogleUser(ctx context.Context, token *oauth2.Token) (*
 	client := s.oauthConfig.Client(ctx, token)
 	resp, err := client.Get("https://www.googleapis.com/oauth2/v2/userinfo")
 	if err != nil {
-		slog.Error("client.Get() error", "err", err)
+		slog.Error("failed to fetch user info from google", "err", err)
 		return nil, fmt.Errorf("failed to get user info: %w", err)
 	}
 	defer resp.Body.Close()
@@ -120,7 +120,7 @@ func (s *AuthService) GetGoogleUser(ctx context.Context, token *oauth2.Token) (*
 
 	var user GoogleUser
 	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
-		slog.Error("json.NewDecoder().Decode() error", "err", err)
+		slog.Error("failed to decode user info response", "err", err)
 		return nil, fmt.Errorf("failed to decode user info: %w", err)
 	}
 
@@ -239,7 +239,7 @@ func (s *AuthService) ValidateToken(tokenString string, expectedType string) (*C
 func GenerateStateToken() (string, error) {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
-		slog.Error("rand.Read() error", "err", err)
+		slog.Error("failed to generate random state token", "err", err)
 		return "", err
 	}
 	return base64.URLEncoding.EncodeToString(b), nil

--- a/internal/pkg/middleware/ratelimit.go
+++ b/internal/pkg/middleware/ratelimit.go
@@ -43,7 +43,7 @@ func RateLimiter(rdb *redis.Client, cfg *RateLimiterConfig) gin.HandlerFunc {
 		}
 		res, err := limiter.Allow(c.Request.Context(), key, limit)
 		if err != nil {
-			slog.Error("rate limiter Allow() error", "key", key, "err", err)
+			slog.Error("failed to check rate limit", "key", key, "err", err)
 			// Redis 不可用时放行请求，避免影响正常服务
 			c.Next()
 			return

--- a/internal/pkg/redis/redis.go
+++ b/internal/pkg/redis/redis.go
@@ -68,18 +68,18 @@ func New(ctx context.Context, cfg Config) (*Client, error) {
 
 	operation := func() error {
 		if err := rdb.Ping(ctx).Err(); err != nil {
-			slog.Error("rdb.Ping() error", "err", err)
-			return fmt.Errorf("rdb.Ping() error, err = %w", err)
+			slog.Error("failed to ping redis", "err", err)
+			return fmt.Errorf("failed to ping redis: %w", err)
 		}
 
 		return nil
 	}
 
 	if err := backoff.Retry(operation, bo); err != nil {
-		slog.Error("backoff.Retry() error", "err", err)
+		slog.Error("failed to connect to redis after retries", "err", err)
 
 		rdb.Close()
-		return nil, fmt.Errorf("backoff.Retry() error, err = %w", err)
+		return nil, fmt.Errorf("failed to connect to redis after retries: %w", err)
 	}
 
 	return &Client{inner: rdb}, nil

--- a/internal/pkg/storage/local.go
+++ b/internal/pkg/storage/local.go
@@ -26,8 +26,8 @@ func NewLocalFileStore(rootDir string) (*LocalFileStore, error) {
 
 	cleanRoot := filepath.Clean(rootDir)
 	if err := os.MkdirAll(cleanRoot, 0755); err != nil {
-		slog.Error("os.MkdirAll() error", "root_dir", cleanRoot, "err", err)
-		return nil, fmt.Errorf("os.MkdirAll() error: %w", err)
+		slog.Error("failed to create root directory", "root_dir", cleanRoot, "err", err)
+		return nil, fmt.Errorf("failed to create root directory: %w", err)
 	}
 
 	return &LocalFileStore{rootDir: cleanRoot}, nil
@@ -51,8 +51,8 @@ func (s *LocalFileStore) Save(ctx context.Context, input SaveInput) (*FileMeta, 
 	absPath := filepath.Join(s.rootDir, relPath)
 
 	if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-		slog.Error("os.MkdirAll() error", "path", absPath, "err", err)
-		return nil, fmt.Errorf("os.MkdirAll() error: %w", err)
+		slog.Error("failed to create directory for file", "path", absPath, "err", err)
+		return nil, fmt.Errorf("failed to create directory for file: %w", err)
 	}
 
 	var sizeBytes int64
@@ -64,8 +64,8 @@ func (s *LocalFileStore) Save(ctx context.Context, input SaveInput) (*FileMeta, 
 		}
 		stat, err := os.Stat(absPath)
 		if err != nil {
-			slog.Error("os.Stat() error", "path", absPath, "err", err)
-			return nil, fmt.Errorf("os.Stat() error: %w", err)
+			slog.Error("failed to stat file", "path", absPath, "err", err)
+			return nil, fmt.Errorf("failed to stat file: %w", err)
 		}
 		sizeBytes = stat.Size()
 		if shaValue == "" {
@@ -83,8 +83,8 @@ func (s *LocalFileStore) Save(ctx context.Context, input SaveInput) (*FileMeta, 
 
 		file, err := os.Create(absPath)
 		if err != nil {
-			slog.Error("os.Create() error", "path", absPath, "err", err)
-			return nil, fmt.Errorf("os.Create() error: %w", err)
+			slog.Error("failed to create file", "path", absPath, "err", err)
+			return nil, fmt.Errorf("failed to create file: %w", err)
 		}
 
 		hasher := sha256.New()
@@ -92,12 +92,12 @@ func (s *LocalFileStore) Save(ctx context.Context, input SaveInput) (*FileMeta, 
 		copied, copyErr := io.Copy(writer, input.Content)
 		closeErr := file.Close()
 		if copyErr != nil {
-			slog.Error("io.Copy() error", "path", absPath, "err", copyErr)
-			return nil, fmt.Errorf("io.Copy() error: %w", copyErr)
+			slog.Error("failed to write file content", "path", absPath, "err", copyErr)
+			return nil, fmt.Errorf("failed to write file content: %w", copyErr)
 		}
 		if closeErr != nil {
-			slog.Error("file.Close() error", "path", absPath, "err", closeErr)
-			return nil, fmt.Errorf("file.Close() error: %w", closeErr)
+			slog.Error("failed to close file after writing", "path", absPath, "err", closeErr)
+			return nil, fmt.Errorf("failed to close file after writing: %w", closeErr)
 		}
 
 		sizeBytes = copied
@@ -123,8 +123,8 @@ func (s *LocalFileStore) Open(ctx context.Context, storagePath string) (io.ReadC
 
 	file, err := os.Open(absPath)
 	if err != nil {
-		slog.Error("os.Open() error", "path", absPath, "err", err)
-		return nil, fmt.Errorf("os.Open() error: %w", err)
+		slog.Error("failed to open file", "path", absPath, "err", err)
+		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
 
 	return file, nil
@@ -139,8 +139,8 @@ func (s *LocalFileStore) Delete(ctx context.Context, storagePath string) error {
 	}
 
 	if err := os.Remove(absPath); err != nil && !os.IsNotExist(err) {
-		slog.Error("os.Remove() error", "path", absPath, "err", err)
-		return fmt.Errorf("os.Remove() error: %w", err)
+		slog.Error("failed to remove file", "path", absPath, "err", err)
+		return fmt.Errorf("failed to remove file: %w", err)
 	}
 
 	return nil
@@ -156,8 +156,8 @@ func (s *LocalFileStore) Stat(ctx context.Context, storagePath string) (*FileMet
 
 	stat, err := os.Stat(absPath)
 	if err != nil {
-		slog.Error("os.Stat() error", "path", absPath, "err", err)
-		return nil, fmt.Errorf("os.Stat() error: %w", err)
+		slog.Error("failed to stat file", "path", absPath, "err", err)
+		return nil, fmt.Errorf("failed to stat file: %w", err)
 	}
 
 	shaValue, err := computeFileSHA256(absPath)
@@ -187,8 +187,8 @@ func (s *LocalFileStore) resolve(storagePath string) (string, error) {
 	absPath := filepath.Join(s.rootDir, cleanPath)
 	rel, err := filepath.Rel(s.rootDir, absPath)
 	if err != nil {
-		slog.Error("filepath.Rel() error", "path", absPath, "err", err)
-		return "", fmt.Errorf("filepath.Rel() error: %w", err)
+		slog.Error("failed to resolve relative path", "path", absPath, "err", err)
+		return "", fmt.Errorf("failed to resolve relative path: %w", err)
 	}
 	if strings.HasPrefix(rel, "..") {
 		slog.Error("storage path escapes root", "storage_path", storagePath)
@@ -208,26 +208,26 @@ func sanitizeFileName(name string) string {
 func copyFile(dstPath, srcPath string) error {
 	src, err := os.Open(srcPath)
 	if err != nil {
-		slog.Error("os.Open() error", "path", srcPath, "err", err)
-		return fmt.Errorf("os.Open() error: %w", err)
+		slog.Error("failed to open source file", "path", srcPath, "err", err)
+		return fmt.Errorf("failed to open source file: %w", err)
 	}
 	defer src.Close()
 
 	dst, err := os.Create(dstPath)
 	if err != nil {
-		slog.Error("os.Create() error", "path", dstPath, "err", err)
-		return fmt.Errorf("os.Create() error: %w", err)
+		slog.Error("failed to create destination file", "path", dstPath, "err", err)
+		return fmt.Errorf("failed to create destination file: %w", err)
 	}
 
 	if _, err := io.Copy(dst, src); err != nil {
 		dst.Close()
-		slog.Error("io.Copy() error", "src", srcPath, "dst", dstPath, "err", err)
-		return fmt.Errorf("io.Copy() error: %w", err)
+		slog.Error("failed to copy file data", "src", srcPath, "dst", dstPath, "err", err)
+		return fmt.Errorf("failed to copy file data: %w", err)
 	}
 
 	if err := dst.Close(); err != nil {
-		slog.Error("dst.Close() error", "path", dstPath, "err", err)
-		return fmt.Errorf("dst.Close() error: %w", err)
+		slog.Error("failed to close destination file", "path", dstPath, "err", err)
+		return fmt.Errorf("failed to close destination file: %w", err)
 	}
 
 	return nil
@@ -236,15 +236,15 @@ func copyFile(dstPath, srcPath string) error {
 func computeFileSHA256(path string) (string, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		slog.Error("os.Open() error", "path", path, "err", err)
-		return "", fmt.Errorf("os.Open() error: %w", err)
+		slog.Error("failed to open file for hashing", "path", path, "err", err)
+		return "", fmt.Errorf("failed to open file for hashing: %w", err)
 	}
 	defer file.Close()
 
 	hasher := sha256.New()
 	if _, err := io.Copy(hasher, file); err != nil {
-		slog.Error("io.Copy() error", "path", path, "err", err)
-		return "", fmt.Errorf("io.Copy() error: %w", err)
+		slog.Error("failed to read file for hashing", "path", path, "err", err)
+		return "", fmt.Errorf("failed to read file for hashing: %w", err)
 	}
 
 	return hex.EncodeToString(hasher.Sum(nil)), nil

--- a/internal/pkg/tools/audio.go
+++ b/internal/pkg/tools/audio.go
@@ -162,7 +162,7 @@ func SaveChatAudioAsset(ctx context.Context, db *gorm.DB, fileStore storage.File
 	}
 
 	if err := db.Create(asset).Error; err != nil {
-		slog.Error("db.Create() error", "err", err, "file_name", fileName)
+		slog.Error("failed to create audio file asset record", "err", err, "file_name", fileName)
 		return nil, fmt.Errorf("failed to persist uploaded audio asset: %w", err)
 	}
 
@@ -184,8 +184,8 @@ func newAudioToolService(db *gorm.DB, fileStore storage.FileStore, genaiClient *
 	}
 	root := filepath.Join(filepath.Clean(workDir), "audio")
 	if err := os.MkdirAll(root, 0755); err != nil {
-		slog.Error("os.MkdirAll() error", "work_dir", root, "err", err)
-		return nil, fmt.Errorf("os.MkdirAll() error: %w", err)
+		slog.Error("failed to create audio work directory", "work_dir", root, "err", err)
+		return nil, fmt.Errorf("failed to create audio work directory: %w", err)
 	}
 
 	return &AudioToolService{
@@ -222,7 +222,7 @@ func (s *AudioToolService) transcribe(ctx context.Context, input AudioTranscribe
 		Prompt:    strings.TrimSpace(input.Prompt),
 	}
 	if err := s.db.Create(job).Error; err != nil {
-		slog.Error("db.Create() error", "file_id", input.FileID, "err", err)
+		slog.Error("failed to create audio job", "file_id", input.FileID, "err", err)
 		return nil, fmt.Errorf("failed to create audio job: %w", err)
 	}
 
@@ -265,7 +265,7 @@ func (s *AudioToolService) transcribe(ctx context.Context, input AudioTranscribe
 		"duration_ms": durationMs,
 		"chunk_count": len(windows),
 	}).Error; err != nil {
-		slog.Error("db.Model().Updates() error", "job_id", job.ID, "err", err)
+		slog.Error("failed to update audio job metadata", "job_id", job.ID, "err", err)
 		s.failJob(job.ID, err)
 		return nil, fmt.Errorf("failed to update audio job metadata: %w", err)
 	}
@@ -326,7 +326,7 @@ func (s *AudioToolService) transcribe(ctx context.Context, input AudioTranscribe
 		"completed_at":     time.Now(),
 		"error_message":    "",
 	}).Error; err != nil {
-		slog.Error("db.Model().Updates() error", "job_id", job.ID, "err", err)
+		slog.Error("failed to complete audio job", "job_id", job.ID, "err", err)
 		return nil, fmt.Errorf("failed to complete audio job: %w", err)
 	}
 
@@ -349,7 +349,7 @@ func (s *AudioToolService) transcribeChunk(ctx context.Context, path string, win
 		DisplayName: filepath.Base(path),
 	})
 	if err != nil {
-		slog.Error("Files.UploadFromPath() error", "path", path, "err", err)
+		slog.Error("failed to upload audio chunk", "path", path, "err", err)
 		return "", fmt.Errorf("failed to upload audio chunk: %w", err)
 	}
 	defer func() {
@@ -373,7 +373,7 @@ func (s *AudioToolService) transcribeChunk(ctx context.Context, path string, win
 
 	resp, err := s.genaiClient.Models.GenerateContent(ctx, defaultAudioModel, contents, nil)
 	if err != nil {
-		slog.Error("Models.GenerateContent() error", "path", path, "err", err)
+		slog.Error("failed to transcribe audio chunk", "path", path, "err", err)
 		return "", fmt.Errorf("failed to transcribe audio chunk: %w", err)
 	}
 
@@ -389,7 +389,7 @@ func (s *AudioToolService) waitForUploadedFile(ctx context.Context, fileName str
 	for {
 		file, err := s.genaiClient.Files.Get(ctx, fileName, nil)
 		if err != nil {
-			slog.Error("Files.Get() error", "file_name", fileName, "err", err)
+			slog.Error("failed to inspect uploaded audio file", "file_name", fileName, "err", err)
 			return nil, fmt.Errorf("failed to inspect uploaded audio file: %w", err)
 		}
 		switch file.State {
@@ -425,7 +425,7 @@ func (s *AudioToolService) persistChunkSuccess(jobID int, window audioChunkWindo
 		TranscriptChars: len(transcript),
 	}
 	if err := s.db.Create(row).Error; err != nil {
-		slog.Error("db.Create() error", "job_id", jobID, "chunk_index", window.index, "err", err)
+		slog.Error("failed to persist audio chunk transcript", "job_id", jobID, "chunk_index", window.index, "err", err)
 		return fmt.Errorf("failed to persist audio chunk transcript: %w", err)
 	}
 	return nil
@@ -469,7 +469,7 @@ func (s *AudioToolService) requireContext(ctx context.Context) (int, string, err
 func (s *AudioToolService) loadAudioAsset(userID, fileID int) (*table.FileAsset, error) {
 	var asset table.FileAsset
 	if err := s.db.Where("id = ? AND user_id = ?", fileID, userID).First(&asset).Error; err != nil {
-		slog.Error("db.First() error", "file_id", fileID, "user_id", userID, "err", err)
+		slog.Error("failed to query audio file asset", "file_id", fileID, "user_id", userID, "err", err)
 		return nil, fmt.Errorf("failed to load file asset: %w", err)
 	}
 	if !IsSupportedAudioMimeType(asset.MimeType) {
@@ -489,7 +489,7 @@ func (s *AudioToolService) markJobRunning(jobID int) error {
 		"status":     constant.AudioJobStatusRunning,
 		"started_at": now,
 	}).Error; err != nil {
-		slog.Error("db.Model().Updates() error", "job_id", jobID, "err", err)
+		slog.Error("failed to mark audio job running", "job_id", jobID, "err", err)
 		return fmt.Errorf("failed to mark audio job running: %w", err)
 	}
 	return nil
@@ -505,15 +505,15 @@ func (s *AudioToolService) failJob(jobID int, cause error) {
 		"error_message": cause.Error(),
 		"completed_at":  now,
 	}).Error; err != nil {
-		slog.Error("db.Model().Updates() error", "job_id", jobID, "err", err)
+		slog.Error("failed to mark audio job as failed", "job_id", jobID, "err", err)
 	}
 }
 
 func (s *AudioToolService) createWorkspace(userID int, sessionID string, jobID int) (string, func(), error) {
 	workspace := filepath.Join(s.workDir, fmt.Sprintf("%d", userID), sessionID, fmt.Sprintf("%d-%s", jobID, uuid.NewString()))
 	if err := os.MkdirAll(workspace, 0755); err != nil {
-		slog.Error("os.MkdirAll() error", "workspace", workspace, "err", err)
-		return "", nil, fmt.Errorf("os.MkdirAll() error: %w", err)
+		slog.Error("failed to create audio workspace", "workspace", workspace, "err", err)
+		return "", nil, fmt.Errorf("failed to create audio workspace: %w", err)
 	}
 
 	cleanup := func() {
@@ -534,18 +534,18 @@ func (s *AudioToolService) materializeAsset(ctx context.Context, asset *table.Fi
 
 	file, err := os.Create(destination)
 	if err != nil {
-		slog.Error("os.Create() error", "path", destination, "err", err)
-		return fmt.Errorf("os.Create() error: %w", err)
+		slog.Error("failed to create file for audio asset", "path", destination, "err", err)
+		return fmt.Errorf("failed to create file for audio asset: %w", err)
 	}
 
 	if _, err := io.Copy(file, rc); err != nil {
 		file.Close()
-		slog.Error("io.Copy() error", "path", destination, "err", err)
-		return fmt.Errorf("io.Copy() error: %w", err)
+		slog.Error("failed to write audio asset data", "path", destination, "err", err)
+		return fmt.Errorf("failed to write audio asset data: %w", err)
 	}
 	if err := file.Close(); err != nil {
-		slog.Error("file.Close() error", "path", destination, "err", err)
-		return fmt.Errorf("file.Close() error: %w", err)
+		slog.Error("failed to close audio asset file", "path", destination, "err", err)
+		return fmt.Errorf("failed to close audio asset file: %w", err)
 	}
 
 	return nil
@@ -688,7 +688,7 @@ func probeAudioDuration(path string) (int64, error) {
 	}
 	durationSeconds, err := strconv.ParseFloat(strings.TrimSpace(string(output)), 64)
 	if err != nil {
-		slog.Error("strconv.ParseFloat() error", "output", strings.TrimSpace(string(output)), "err", err)
+		slog.Error("failed to parse audio duration", "output", strings.TrimSpace(string(output)), "err", err)
 		return 0, fmt.Errorf("invalid ffprobe duration output: %w", err)
 	}
 	return int64(durationSeconds * 1000), nil

--- a/internal/pkg/tools/calendar.go
+++ b/internal/pkg/tools/calendar.go
@@ -79,7 +79,7 @@ type calendarHandler struct {
 func (h *calendarHandler) buildService(ctx context.Context, userID int) (*calendar.Service, error) {
 	var user table.User
 	if err := h.db.WithContext(ctx).Where("id = ?", userID).First(&user).Error; err != nil {
-		slog.Error("db.First() error in calendar tool", "err", err)
+		slog.Error("failed to query user for calendar", "err", err)
 		return nil, fmt.Errorf("user not found: %w", err)
 	}
 
@@ -103,13 +103,13 @@ func (h *calendarHandler) buildService(ctx context.Context, userID int) (*calend
 	}
 	if newToken.RefreshToken != "" && newToken.RefreshToken != user.GoogleOAuthRefreshToken {
 		if updateErr := h.db.Model(&user).Update("google_oauth_refresh_token", newToken.RefreshToken).Error; updateErr != nil {
-			slog.Error("db.Update() failed to persist rotated refresh_token", "err", updateErr)
+			slog.Error("failed to persist rotated refresh token", "err", updateErr)
 		}
 	}
 
 	svc, err := calendar.NewService(ctx, googleoption.WithTokenSource(ts))
 	if err != nil {
-		slog.Error("calendar.NewService() error", "err", err)
+		slog.Error("failed to create calendar service", "err", err)
 		return nil, fmt.Errorf("failed to create calendar service: %w", err)
 	}
 	return svc, nil

--- a/internal/pkg/tools/email.go
+++ b/internal/pkg/tools/email.go
@@ -119,8 +119,8 @@ func querySingleServer(ctx context.Context, input EmailQueryInput) (*EmailQueryO
 
 	// 查找用户的邮件服务器配置
 	if err := tx.Where("user_id = ?", userID).Order("is_default DESC, created_at DESC").Find(&emailServerConfigs).Error; err != nil {
-		slog.Error("tx.Find() error", "err", err)
-		return nil, fmt.Errorf("tx.Find() error, err = %w", err)
+		slog.Error("failed to query email server configs", "err", err)
+		return nil, fmt.Errorf("failed to query email server configs: %w", err)
 	}
 
 	if len(emailServerConfigs) == 0 {
@@ -240,13 +240,13 @@ func connectToIMAP(server, username, password string) (*imapclient.Client, error
 
 	client, err := imapclient.DialTLS(server, options)
 	if err != nil {
-		slog.Error("imapclient.DialTLS() error", "err", err)
+		slog.Error("failed to connect to imap server", "err", err)
 		return nil, fmt.Errorf("连接 IMAP 服务器失败: %w", err)
 	}
 
 	if err := client.Login(username, password).Wait(); err != nil {
 		client.Close()
-		slog.Error("client.Login() error", "err", err)
+		slog.Error("failed to authenticate with imap server", "err", err)
 		return nil, fmt.Errorf("IMAP 登录失败: %w", err)
 	}
 

--- a/internal/pkg/tools/exasearch.go
+++ b/internal/pkg/tools/exasearch.go
@@ -180,7 +180,7 @@ func searchExaWithURL(ctx context.Context, query string, numResults int, include
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
-		slog.Error("json.Marshal() error", "err", err)
+		slog.Error("failed to marshal exa request body", "err", err)
 		return nil, fmt.Errorf("序列化请求体失败: %w", err)
 	}
 
@@ -190,7 +190,7 @@ func searchExaWithURL(ctx context.Context, query string, numResults int, include
 	// 创建 HTTP 请求
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(bodyBytes))
 	if err != nil {
-		slog.Error("http.NewRequestWithContext() error", "url", apiURL, "err", err)
+		slog.Error("failed to create exa search request", "url", apiURL, "err", err)
 		return nil, fmt.Errorf("创建请求失败: %w", err)
 	}
 
@@ -201,7 +201,7 @@ func searchExaWithURL(ctx context.Context, query string, numResults int, include
 	// 发送请求
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		slog.Error("http.DefaultClient.Do() error", "url", apiURL, "err", err)
+		slog.Error("failed to send exa search request", "url", apiURL, "err", err)
 		return nil, fmt.Errorf("请求失败: %w", err)
 	}
 	defer resp.Body.Close()
@@ -209,7 +209,7 @@ func searchExaWithURL(ctx context.Context, query string, numResults int, include
 	// 读取响应
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		slog.Error("io.ReadAll() error", "err", err)
+		slog.Error("failed to read exa search response", "err", err)
 		return nil, fmt.Errorf("读取响应失败: %w", err)
 	}
 
@@ -222,7 +222,7 @@ func searchExaWithURL(ctx context.Context, query string, numResults int, include
 	// 解析 JSON 响应
 	var exaResp exaResponse
 	if err := json.Unmarshal(body, &exaResp); err != nil {
-		slog.Error("json.Unmarshal() error", "err", err)
+		slog.Error("failed to parse exa search response", "err", err)
 		return nil, fmt.Errorf("解析 JSON 失败: %w", err)
 	}
 

--- a/internal/pkg/tools/file_asset.go
+++ b/internal/pkg/tools/file_asset.go
@@ -102,7 +102,7 @@ func NewFileListTool(db *gorm.DB) (tool.Tool, error) {
 
 		var assets []table.FileAsset
 		if err := query.Order("created_at DESC").Limit(limit).Find(&assets).Error; err != nil {
-			slog.Error("query.Find() error", "user_id", userID, "err", err)
+			slog.Error("failed to list file assets", "user_id", userID, "err", err)
 			return nil, fmt.Errorf("failed to list files: %w", err)
 		}
 
@@ -150,7 +150,7 @@ func NewFileGetTool(db *gorm.DB) (tool.Tool, error) {
 
 		var asset table.FileAsset
 		if err := db.Where("id = ? AND user_id = ?", input.FileID, userID).First(&asset).Error; err != nil {
-			slog.Error("db.First() error", "file_id", input.FileID, "user_id", userID, "err", err)
+			slog.Error("failed to query file asset", "file_id", input.FileID, "user_id", userID, "err", err)
 			return nil, fmt.Errorf("failed to get file: %w", err)
 		}
 

--- a/internal/pkg/tools/file_download.go
+++ b/internal/pkg/tools/file_download.go
@@ -138,14 +138,14 @@ func downloadRemoteFile(ctx context.Context, input FileDownloadInput) ([]byte, s
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
 	if err != nil {
-		slog.Error("http.NewRequestWithContext() error", "url", parsedURL.String(), "err", err)
+		slog.Error("failed to create download request", "url", parsedURL.String(), "err", err)
 		return nil, "", "", fmt.Errorf("failed to create download request: %w", err)
 	}
 	req.Header.Set("User-Agent", fileDownloadUserAgent)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		slog.Error("http.DefaultClient.Do() error", "url", parsedURL.String(), "err", err)
+		slog.Error("failed to download file", "url", parsedURL.String(), "err", err)
 		return nil, "", "", fmt.Errorf("failed to download file: %w", err)
 	}
 	defer resp.Body.Close()
@@ -164,7 +164,7 @@ func downloadRemoteFile(ctx context.Context, input FileDownloadInput) ([]byte, s
 	limitedReader := io.LimitReader(resp.Body, maxBytes+1)
 	data, err := io.ReadAll(limitedReader)
 	if err != nil {
-		slog.Error("io.ReadAll() error", "url", parsedURL.String(), "err", err)
+		slog.Error("failed to read downloaded file", "url", parsedURL.String(), "err", err)
 		return nil, "", "", fmt.Errorf("failed to read downloaded file: %w", err)
 	}
 	if int64(len(data)) > maxBytes {

--- a/internal/pkg/tools/imagegen.go
+++ b/internal/pkg/tools/imagegen.go
@@ -227,13 +227,13 @@ func generateMockImages(numberOfImages int32, aspectRatio string) (*ImageGenOutp
 		// 将图片转换为 base64
 		buf := new(bytes.Buffer)
 		if err := png.Encode(buf, img); err != nil {
-			slog.Error("png.Encode() error", "err", err)
+			slog.Error("failed to encode mock image as png", "err", err)
 			continue
 		}
 
 		data, err := os.ReadFile("/Users/yuncheng/Documents/github/aiguides/cmd/aiguide/image1.png")
 		if err != nil {
-			slog.Error("os.ReadFile() error", "err", err)
+			slog.Error("failed to read mock image file", "err", err)
 			continue
 		}
 

--- a/internal/pkg/tools/memory.go
+++ b/internal/pkg/tools/memory.go
@@ -309,7 +309,7 @@ func (h *memoryHandler) deleteMemory(input *MemoryInput, userID int) (*MemoryOut
 func SerializeMemoryOutput(output *MemoryOutput) string {
 	data, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
-		slog.Error("json.MarshalIndent() error", "err", err)
+		slog.Error("failed to serialize memory output", "err", err)
 		return fmt.Sprintf("error serializing output: %v", err)
 	}
 

--- a/internal/pkg/tools/pdf.go
+++ b/internal/pkg/tools/pdf.go
@@ -128,8 +128,8 @@ func newPDFToolService(db *gorm.DB, fileStore storage.FileStore, workDir string)
 		return nil, fmt.Errorf("pdf work directory is required")
 	}
 	if err := os.MkdirAll(workDir, 0755); err != nil {
-		slog.Error("os.MkdirAll() error", "work_dir", workDir, "err", err)
-		return nil, fmt.Errorf("os.MkdirAll() error: %w", err)
+		slog.Error("failed to create pdf work directory", "work_dir", workDir, "err", err)
+		return nil, fmt.Errorf("failed to create pdf work directory: %w", err)
 	}
 
 	return &PDFToolService{
@@ -291,7 +291,7 @@ func (s *PDFToolService) requireContext(ctx context.Context) (int, string, error
 func (s *PDFToolService) loadPDFAsset(userID, fileID int) (*table.FileAsset, error) {
 	var asset table.FileAsset
 	if err := s.db.Where("id = ? AND user_id = ?", fileID, userID).First(&asset).Error; err != nil {
-		slog.Error("db.First() error", "file_id", fileID, "user_id", userID, "err", err)
+		slog.Error("failed to query pdf file asset", "file_id", fileID, "user_id", userID, "err", err)
 		return nil, fmt.Errorf("failed to load file asset: %w", err)
 	}
 	if asset.MimeType != "application/pdf" {
@@ -308,8 +308,8 @@ func (s *PDFToolService) loadPDFAsset(userID, fileID int) (*table.FileAsset, err
 func (s *PDFToolService) createJob(userID int, sessionID string, jobType constant.PDFJobType, params map[string]any) (*table.PDFJob, error) {
 	paramsJSON, err := json.Marshal(params)
 	if err != nil {
-		slog.Error("json.Marshal() error", "err", err)
-		return nil, fmt.Errorf("json.Marshal() error: %w", err)
+		slog.Error("failed to marshal pdf job params", "err", err)
+		return nil, fmt.Errorf("failed to marshal pdf job params: %w", err)
 	}
 
 	job := &table.PDFJob{
@@ -321,7 +321,7 @@ func (s *PDFToolService) createJob(userID int, sessionID string, jobType constan
 	}
 
 	if err := s.db.Create(job).Error; err != nil {
-		slog.Error("db.Create() error", "err", err, "job_type", jobType)
+		slog.Error("failed to create pdf job", "err", err, "job_type", jobType)
 		return nil, fmt.Errorf("failed to create pdf job: %w", err)
 	}
 
@@ -334,7 +334,7 @@ func (s *PDFToolService) markJobRunning(jobID int) error {
 		"status":     constant.PDFJobStatusRunning,
 		"started_at": now,
 	}).Error; err != nil {
-		slog.Error("db.Model().Updates() error", "job_id", jobID, "err", err)
+		slog.Error("failed to mark pdf job running", "job_id", jobID, "err", err)
 		return fmt.Errorf("failed to mark pdf job running: %w", err)
 	}
 	return nil
@@ -352,7 +352,7 @@ func (s *PDFToolService) completeJob(jobID int, summary string, outputFileID int
 	}
 
 	if err := s.db.Model(&table.PDFJob{}).Where("id = ?", jobID).Updates(updates).Error; err != nil {
-		slog.Error("db.Model().Updates() error", "job_id", jobID, "err", err)
+		slog.Error("failed to complete pdf job", "job_id", jobID, "err", err)
 		return fmt.Errorf("failed to complete pdf job: %w", err)
 	}
 	return nil
@@ -368,15 +368,15 @@ func (s *PDFToolService) failJob(jobID int, cause error) {
 		"error_message": cause.Error(),
 		"completed_at":  now,
 	}).Error; err != nil {
-		slog.Error("db.Model().Updates() error", "job_id", jobID, "err", err)
+		slog.Error("failed to mark pdf job as failed", "job_id", jobID, "err", err)
 	}
 }
 
 func (s *PDFToolService) createWorkspace(userID int, sessionID string, jobID int) (string, func(), error) {
 	workspace := filepath.Join(s.workDir, fmt.Sprintf("%d", userID), sessionID, fmt.Sprintf("%d-%s", jobID, uuid.NewString()))
 	if err := os.MkdirAll(workspace, 0755); err != nil {
-		slog.Error("os.MkdirAll() error", "workspace", workspace, "err", err)
-		return "", nil, fmt.Errorf("os.MkdirAll() error: %w", err)
+		slog.Error("failed to create pdf workspace", "workspace", workspace, "err", err)
+		return "", nil, fmt.Errorf("failed to create pdf workspace: %w", err)
 	}
 
 	cleanup := func() {
@@ -397,18 +397,18 @@ func (s *PDFToolService) materializeAsset(ctx context.Context, asset *table.File
 
 	file, err := os.Create(destination)
 	if err != nil {
-		slog.Error("os.Create() error", "path", destination, "err", err)
-		return fmt.Errorf("os.Create() error: %w", err)
+		slog.Error("failed to create file for pdf asset", "path", destination, "err", err)
+		return fmt.Errorf("failed to create file for pdf asset: %w", err)
 	}
 
 	if _, err := io.Copy(file, rc); err != nil {
 		file.Close()
-		slog.Error("io.Copy() error", "path", destination, "err", err)
-		return fmt.Errorf("io.Copy() error: %w", err)
+		slog.Error("failed to write pdf asset data", "path", destination, "err", err)
+		return fmt.Errorf("failed to write pdf asset data: %w", err)
 	}
 	if err := file.Close(); err != nil {
-		slog.Error("file.Close() error", "path", destination, "err", err)
-		return fmt.Errorf("file.Close() error: %w", err)
+		slog.Error("failed to close pdf asset file", "path", destination, "err", err)
+		return fmt.Errorf("failed to close pdf asset file: %w", err)
 	}
 
 	return nil
@@ -439,7 +439,7 @@ func (s *PDFToolService) saveGeneratedAsset(ctx context.Context, userID int, ses
 	}
 
 	if err := s.db.Create(asset).Error; err != nil {
-		slog.Error("db.Create() error", "err", err, "file_name", fileName)
+		slog.Error("failed to create generated pdf file asset", "err", err, "file_name", fileName)
 		return nil, fmt.Errorf("failed to persist file asset: %w", err)
 	}
 
@@ -449,8 +449,8 @@ func (s *PDFToolService) saveGeneratedAsset(ctx context.Context, userID int, ses
 func extractPDFPageTexts(path string) ([]PDFPageText, int, error) {
 	file, reader, err := pdf.Open(path)
 	if err != nil {
-		slog.Error("pdf.Open() error", "path", path, "err", err)
-		return nil, 0, fmt.Errorf("pdf.Open() error: %w", err)
+		slog.Error("failed to open pdf file", "path", path, "err", err)
+		return nil, 0, fmt.Errorf("failed to open pdf file: %w", err)
 	}
 	defer file.Close()
 
@@ -470,8 +470,8 @@ func extractPDFPageTexts(path string) ([]PDFPageText, int, error) {
 		}
 		text, err := page.GetPlainText(fonts)
 		if err != nil {
-			slog.Error("page.GetPlainText() error", "path", path, "page_number", pageNumber, "err", err)
-			return nil, 0, fmt.Errorf("page.GetPlainText() error: %w", err)
+			slog.Error("failed to extract text from pdf page", "path", path, "page_number", pageNumber, "err", err)
+			return nil, 0, fmt.Errorf("failed to extract text from pdf page: %w", err)
 		}
 		pages = append(pages, PDFPageText{
 			PageNumber: pageNumber,
@@ -517,13 +517,13 @@ func generatePDFDocument(path, title, metadataTitle string, paragraphs []string)
 		fontFamily = "AIGuidesUnicode"
 		fontBytes, err := os.ReadFile(fontPath)
 		if err != nil {
-			slog.Error("os.ReadFile() error", "font_path", fontPath, "err", err)
-			return fmt.Errorf("os.ReadFile() error: %w", err)
+			slog.Error("failed to read font file", "font_path", fontPath, "err", err)
+			return fmt.Errorf("failed to read font file: %w", err)
 		}
 		pdfDoc.AddUTF8FontFromBytes(fontFamily, "", fontBytes)
 		if pdfDoc.Error() != nil {
-			slog.Error("pdfDoc.AddUTF8FontFromBytes() error", "font_path", fontPath, "err", pdfDoc.Error())
-			return fmt.Errorf("pdfDoc.AddUTF8FontFromBytes() error: %w", pdfDoc.Error())
+			slog.Error("failed to add utf8 font to pdf", "font_path", fontPath, "err", pdfDoc.Error())
+			return fmt.Errorf("failed to add utf8 font to pdf: %w", pdfDoc.Error())
 		}
 	} else if containsNonASCII(allText) {
 		slog.Error("no utf8 font available for pdf generation")
@@ -545,8 +545,8 @@ func generatePDFDocument(path, title, metadataTitle string, paragraphs []string)
 	}
 
 	if err := pdfDoc.OutputFileAndClose(path); err != nil {
-		slog.Error("pdfDoc.OutputFileAndClose() error", "path", path, "err", err)
-		return fmt.Errorf("pdfDoc.OutputFileAndClose() error: %w", err)
+		slog.Error("failed to write pdf output file", "path", path, "err", err)
+		return fmt.Errorf("failed to write pdf output file: %w", err)
 	}
 
 	return nil
@@ -634,7 +634,7 @@ func SaveChatPDFAsset(ctx context.Context, db *gorm.DB, fileStore storage.FileSt
 	}
 
 	if err := db.Create(asset).Error; err != nil {
-		slog.Error("db.Create() error", "err", err, "file_name", fileName)
+		slog.Error("failed to create uploaded pdf file asset", "err", err, "file_name", fileName)
 		return nil, fmt.Errorf("failed to persist uploaded pdf asset: %w", err)
 	}
 
@@ -646,7 +646,7 @@ func SaveChatPDFAsset(ctx context.Context, db *gorm.DB, fileStore storage.FileSt
 			"text_chars":  0,
 			"text_error":  err.Error(),
 		}).Error; updateErr != nil {
-			slog.Error("db.Model().Updates() error", "file_id", asset.ID, "err", updateErr)
+			slog.Error("failed to update pdf text extraction status", "file_id", asset.ID, "err", updateErr)
 		}
 		asset.TextStatus = constant.PDFTextExtractStatusFailed
 		asset.TextError = err.Error()
@@ -674,7 +674,7 @@ func SaveChatPDFAsset(ctx context.Context, db *gorm.DB, fileStore storage.FileSt
 
 	if len(pageRows) > 0 {
 		if err := db.Create(&pageRows).Error; err != nil {
-			slog.Error("db.Create() error", "file_id", asset.ID, "err", err)
+			slog.Error("failed to persist extracted pdf text pages", "file_id", asset.ID, "err", err)
 			return nil, fmt.Errorf("failed to persist extracted pdf text: %w", err)
 		}
 	}
@@ -686,7 +686,7 @@ func SaveChatPDFAsset(ctx context.Context, db *gorm.DB, fileStore storage.FileSt
 		"text_error":  "",
 	}
 	if err := db.Model(&table.FileAsset{}).Where("id = ?", asset.ID).Updates(updates).Error; err != nil {
-		slog.Error("db.Model().Updates() error", "file_id", asset.ID, "err", err)
+		slog.Error("failed to update pdf text extraction metadata", "file_id", asset.ID, "err", err)
 		return nil, fmt.Errorf("failed to update extracted pdf metadata: %w", err)
 	}
 
@@ -707,8 +707,8 @@ func SaveChatPDFAsset(ctx context.Context, db *gorm.DB, fileStore storage.FileSt
 func extractPDFBytesToPageTexts(data []byte) ([]PDFPageText, int, error) {
 	file, err := os.CreateTemp("", "aiguides-upload-*.pdf")
 	if err != nil {
-		slog.Error("os.CreateTemp() error", "err", err)
-		return nil, 0, fmt.Errorf("os.CreateTemp() error: %w", err)
+		slog.Error("failed to create temp file for pdf", "err", err)
+		return nil, 0, fmt.Errorf("failed to create temp file for pdf: %w", err)
 	}
 	path := file.Name()
 	defer func() {
@@ -719,12 +719,12 @@ func extractPDFBytesToPageTexts(data []byte) ([]PDFPageText, int, error) {
 
 	if _, err := file.Write(data); err != nil {
 		file.Close()
-		slog.Error("file.Write() error", "path", path, "err", err)
-		return nil, 0, fmt.Errorf("file.Write() error: %w", err)
+		slog.Error("failed to write pdf data to temp file", "path", path, "err", err)
+		return nil, 0, fmt.Errorf("failed to write pdf data to temp file: %w", err)
 	}
 	if err := file.Close(); err != nil {
-		slog.Error("file.Close() error", "path", path, "err", err)
-		return nil, 0, fmt.Errorf("file.Close() error: %w", err)
+		slog.Error("failed to close temp pdf file", "path", path, "err", err)
+		return nil, 0, fmt.Errorf("failed to close temp pdf file: %w", err)
 	}
 
 	return extractPDFPageTexts(path)

--- a/internal/pkg/tools/scheduled_task.go
+++ b/internal/pkg/tools/scheduled_task.go
@@ -91,7 +91,7 @@ func NewScheduledTaskCreateTool(db *gorm.DB) (tool.Tool, error) {
 		}
 
 		if err := db.Create(scheduledTask).Error; err != nil {
-			slog.Error("db.Create() error", "err", err)
+			slog.Error("failed to create scheduled task", "err", err)
 			return nil, fmt.Errorf("failed to create scheduled task: %w", err)
 		}
 
@@ -134,7 +134,7 @@ func NewScheduledTaskListTool(db *gorm.DB) (tool.Tool, error) {
 
 		var tasks []table.ScheduledTask
 		if err := query.Order("next_run_at ASC").Find(&tasks).Error; err != nil {
-			slog.Error("query.Find() error", "err", err)
+			slog.Error("failed to list scheduled tasks", "err", err)
 			return nil, fmt.Errorf("failed to list scheduled tasks: %w", err)
 		}
 
@@ -195,7 +195,7 @@ func normalizeScheduledTaskInput(input ScheduledTaskCreateInput) (ScheduledTaskC
 func CalculateNextRunAt(now time.Time, input ScheduledTaskCreateInput) (time.Time, error) {
 	location, err := time.LoadLocation(input.Timezone)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("time.LoadLocation() error, err = %w", err)
+		return time.Time{}, fmt.Errorf("failed to load timezone: %w", err)
 	}
 	nowInLocation := now.In(location)
 

--- a/internal/pkg/tools/send_email.go
+++ b/internal/pkg/tools/send_email.go
@@ -80,7 +80,7 @@ func sendEmail(ctx context.Context, input SendEmailInput) (*SendEmailOutput, err
 
 	defaultedToSelf, err := populateDefaultRecipient(&validatedInput, emailServerConfig.Username)
 	if err != nil {
-		slog.Error("populateDefaultRecipient() error", "username", emailServerConfig.Username, "err", err)
+		slog.Error("failed to populate default recipient", "username", emailServerConfig.Username, "err", err)
 		return &SendEmailOutput{
 			Success:    false,
 			Error:      fmt.Sprintf("默认收件人无效: %v", err),
@@ -102,12 +102,12 @@ func sendEmail(ctx context.Context, input SendEmailInput) (*SendEmailOutput, err
 
 	message, err := buildEmailMessage(emailServerConfig.Username, fromName, validatedInput, recipients)
 	if err != nil {
-		slog.Error("buildEmailMessage() error", "err", err)
-		return nil, fmt.Errorf("buildEmailMessage() error, err = %w", err)
+		slog.Error("failed to build email message", "err", err)
+		return nil, fmt.Errorf("failed to build email message: %w", err)
 	}
 
 	if err := sendSMTPMessage(emailServerConfig.SMTPServer, emailServerConfig.Username, emailServerConfig.Password, recipients, message); err != nil {
-		slog.Error("sendSMTPMessage() error", "smtp_server", emailServerConfig.SMTPServer, "config_name", emailServerConfig.Name, "err", err)
+		slog.Error("failed to send smtp message", "smtp_server", emailServerConfig.SMTPServer, "config_name", emailServerConfig.Name, "err", err)
 		return &SendEmailOutput{
 			Success:    false,
 			Error:      fmt.Sprintf("发送邮件失败: %v", err),
@@ -227,8 +227,8 @@ func loadEmailServerConfigForSending(ctx context.Context, configName string) (*t
 		query = query.Where("name = ?", configName)
 	}
 	if err := query.Find(&emailServerConfigs).Error; err != nil {
-		slog.Error("query.Find() error", "user_id", userID, "config_name", configName, "err", err)
-		return nil, nil, fmt.Errorf("query.Find() error, err = %w", err)
+		slog.Error("failed to query email server configs for sending", "user_id", userID, "config_name", configName, "err", err)
+		return nil, nil, fmt.Errorf("failed to query email server configs: %w", err)
 	}
 
 	if len(emailServerConfigs) == 0 {
@@ -311,14 +311,14 @@ func sendSMTPMessage(serverAddr, username, password string, recipients []string,
 	if strings.HasSuffix(serverAddr, ":465") {
 		conn, err := tls.Dial("tcp", serverAddr, &tls.Config{ServerName: host})
 		if err != nil {
-			slog.Error("tls.Dial() error", "smtp_server", serverAddr, "err", err)
+			slog.Error("failed to connect to smtp server via tls", "smtp_server", serverAddr, "err", err)
 			return fmt.Errorf("连接 SMTP 服务器失败: %w", err)
 		}
 
 		client, err := smtp.NewClient(conn, host)
 		if err != nil {
 			conn.Close()
-			slog.Error("smtp.NewClient() error", "smtp_server", serverAddr, "err", err)
+			slog.Error("failed to create smtp client", "smtp_server", serverAddr, "err", err)
 			return fmt.Errorf("初始化 SMTP 客户端失败: %w", err)
 		}
 
@@ -327,14 +327,14 @@ func sendSMTPMessage(serverAddr, username, password string, recipients []string,
 
 	client, err := smtp.Dial(serverAddr)
 	if err != nil {
-		slog.Error("smtp.Dial() error", "smtp_server", serverAddr, "err", err)
+		slog.Error("failed to dial smtp server", "smtp_server", serverAddr, "err", err)
 		return fmt.Errorf("连接 SMTP 服务器失败: %w", err)
 	}
 
 	if ok, _ := client.Extension("STARTTLS"); ok {
 		if err := client.StartTLS(&tls.Config{ServerName: host}); err != nil {
 			client.Close()
-			slog.Error("client.StartTLS() error", "smtp_server", serverAddr, "err", err)
+			slog.Error("failed to start tls on smtp connection", "smtp_server", serverAddr, "err", err)
 			return fmt.Errorf("启动 SMTP TLS 失败: %w", err)
 		}
 	}
@@ -347,41 +347,41 @@ func sendSMTPWithClient(client *smtp.Client, host, username, password string, re
 
 	if ok, _ := client.Extension("AUTH"); ok && username != "" {
 		if err := client.Auth(smtp.PlainAuth("", username, password, host)); err != nil {
-			slog.Error("client.Auth() error", "smtp_host", host, "username", username, "err", err)
+			slog.Error("failed to authenticate with smtp server", "smtp_host", host, "username", username, "err", err)
 			return fmt.Errorf("SMTP 认证失败: %w", err)
 		}
 	}
 
 	if err := client.Mail(username); err != nil {
-		slog.Error("client.Mail() error", "from", username, "err", err)
+		slog.Error("failed to set smtp sender", "from", username, "err", err)
 		return fmt.Errorf("设置发件人失败: %w", err)
 	}
 
 	for _, recipient := range recipients {
 		if err := client.Rcpt(recipient); err != nil {
-			slog.Error("client.Rcpt() error", "recipient", recipient, "err", err)
+			slog.Error("failed to add smtp recipient", "recipient", recipient, "err", err)
 			return fmt.Errorf("添加收件人 %s 失败: %w", recipient, err)
 		}
 	}
 
 	writer, err := client.Data()
 	if err != nil {
-		slog.Error("client.Data() error", "err", err)
+		slog.Error("failed to open smtp data stream", "err", err)
 		return fmt.Errorf("创建邮件数据流失败: %w", err)
 	}
 
 	if _, err := writer.Write(message); err != nil {
 		writer.Close()
-		slog.Error("writer.Write() error", "err", err)
+		slog.Error("failed to write email message data", "err", err)
 		return fmt.Errorf("写入邮件内容失败: %w", err)
 	}
 	if err := writer.Close(); err != nil {
-		slog.Error("writer.Close() error", "err", err)
+		slog.Error("failed to close smtp data stream", "err", err)
 		return fmt.Errorf("完成邮件写入失败: %w", err)
 	}
 
 	if err := client.Quit(); err != nil {
-		slog.Error("client.Quit() error", "err", err)
+		slog.Error("failed to quit smtp session", "err", err)
 		return fmt.Errorf("结束 SMTP 会话失败: %w", err)
 	}
 

--- a/internal/pkg/tools/ssh.go
+++ b/internal/pkg/tools/ssh.go
@@ -75,13 +75,13 @@ func executeSSHCommand(ctx context.Context, input SSHExecuteInput) (*SSHExecuteO
 
 	tx, ok := middleware.GetTx(ctx)
 	if !ok {
-		slog.Error("middleware.GetTx() failed in executeSSHCommand")
+		slog.Error("failed to get database context for ssh", "err", "middleware.GetTx() returned false")
 		return &SSHExecuteOutput{Success: false, Error: "internal error: database context unavailable"}, nil
 	}
 
 	userID, ok := middleware.GetUserID(ctx)
 	if !ok {
-		slog.Error("middleware.GetUserID() failed in executeSSHCommand")
+		slog.Error("failed to get user context for ssh", "err", "middleware.GetUserID() returned false")
 		return &SSHExecuteOutput{Success: false, Error: "internal error: user context unavailable"}, nil
 	}
 
@@ -90,7 +90,7 @@ func executeSSHCommand(ctx context.Context, input SSHExecuteInput) (*SSHExecuteO
 	if input.ServerName != "" {
 		if err := tx.Where("user_id = ? AND name = ?", userID, input.ServerName).
 			First(&serverCfg).Error; err != nil {
-			slog.Error("db.First() error in executeSSHCommand", "user_id", userID, "server_name", input.ServerName, "err", err)
+			slog.Error("failed to query ssh server config by name", "user_id", userID, "server_name", input.ServerName, "err", err)
 			return &SSHExecuteOutput{
 				Success:     false,
 				Error:       fmt.Sprintf("SSH server config %q not found. Please add it at /settings/ssh-servers.", input.ServerName),
@@ -102,7 +102,7 @@ func executeSSHCommand(ctx context.Context, input SSHExecuteInput) (*SSHExecuteO
 		if err := tx.Where("user_id = ?", userID).
 			Order("is_default DESC, created_at DESC").
 			First(&serverCfg).Error; err != nil {
-			slog.Error("db.First() error finding default SSH config", "user_id", userID, "err", err)
+			slog.Error("failed to query default ssh server config", "user_id", userID, "err", err)
 			return &SSHExecuteOutput{
 				Success:     false,
 				Error:       "No SSH server config found. Please add one at /settings/ssh-servers.",
@@ -113,7 +113,7 @@ func executeSSHCommand(ctx context.Context, input SSHExecuteInput) (*SSHExecuteO
 
 	authMethods, err := buildAuthMethods(serverCfg)
 	if err != nil {
-		slog.Error("buildAuthMethods() error", "host", serverCfg.Host, "err", err)
+		slog.Error("failed to build ssh auth methods", "host", serverCfg.Host, "err", err)
 		return &SSHExecuteOutput{
 			Success: false,
 			Host:    fmt.Sprintf("%s:%d", serverCfg.Host, serverCfg.Port),
@@ -127,7 +127,7 @@ func executeSSHCommand(ctx context.Context, input SSHExecuteInput) (*SSHExecuteO
 
 	output, err := runSSHCommand(ctx, host, serverCfg.Username, authMethods, input.Command)
 	if err != nil {
-		slog.Error("runSSHCommand() error", "host", host, "err", err)
+		slog.Error("failed to run ssh command", "host", host, "err", err)
 		return &SSHExecuteOutput{
 			Success: false,
 			Host:    host,
@@ -298,13 +298,13 @@ func NewSSHListServersTool() (tool.Tool, error) {
 	handler := func(ctx tool.Context, _ SSHListServersInput) (*SSHListServersOutput, error) {
 		tx, ok := middleware.GetTx(ctx)
 		if !ok {
-			slog.Error("middleware.GetTx() failed in ssh_list_servers")
+			slog.Error("failed to get database context for ssh list servers")
 			return &SSHListServersOutput{}, nil
 		}
 
 		userID, ok := middleware.GetUserID(ctx)
 		if !ok {
-			slog.Error("middleware.GetUserID() failed in ssh_list_servers")
+			slog.Error("failed to get user context for ssh list servers")
 			return &SSHListServersOutput{}, nil
 		}
 
@@ -312,7 +312,7 @@ func NewSSHListServersTool() (tool.Tool, error) {
 		if err := tx.Where("user_id = ?", userID).
 			Order("is_default DESC, created_at DESC").
 			Find(&configs).Error; err != nil {
-			slog.Error("db.Find() error in ssh_list_servers", "user_id", userID, "err", err)
+			slog.Error("failed to query ssh server configs", "user_id", userID, "err", err)
 			return &SSHListServersOutput{}, nil
 		}
 

--- a/internal/pkg/tools/videogen.go
+++ b/internal/pkg/tools/videogen.go
@@ -137,7 +137,7 @@ func generateVideo(ctx context.Context, client *genai.Client, db *gorm.DB, fileS
 
 	operation, err := client.Models.GenerateVideos(ctx, DefaultVideoModel, prompt, nil, genConfig)
 	if err != nil {
-		slog.Error("client.Models.GenerateVideos() error", "err", err)
+		slog.Error("failed to generate video", "err", err)
 		return &VideoGenOutput{
 			Success: false,
 			Error:   fmt.Sprintf("视频生成请求失败: %v", err),
@@ -163,7 +163,7 @@ func generateVideo(ctx context.Context, client *genai.Client, db *gorm.DB, fileS
 
 		operation, err = client.Operations.GetVideosOperation(ctx, operation, nil)
 		if err != nil {
-			slog.Error("client.Operations.GetVideosOperation() error", "err", err)
+			slog.Error("failed to poll video generation status", "err", err)
 			return &VideoGenOutput{
 				Success: false,
 				Error:   fmt.Sprintf("查询视频生成状态失败: %v", err),
@@ -235,7 +235,7 @@ func generateVideo(ctx context.Context, client *genai.Client, db *gorm.DB, fileS
 		}
 
 		if err := db.Create(asset).Error; err != nil {
-			slog.Error("db.Create() FileAsset error", "err", err, "file_name", fileName)
+			slog.Error("failed to create video file asset record", "err", err, "file_name", fileName)
 			continue
 		}
 

--- a/internal/pkg/tools/webfetch.go
+++ b/internal/pkg/tools/webfetch.go
@@ -92,7 +92,7 @@ func executeWebFetch(ctx context.Context, input WebFetchInput) (*WebFetchOutput,
 
 	req, err := http.NewRequestWithContext(ctx, "GET", input.URL, nil)
 	if err != nil {
-		slog.Error("http.NewRequestWithContext() error", "url", input.URL, "err", err)
+		slog.Error("failed to create web fetch request", "url", input.URL, "err", err)
 		return &WebFetchOutput{
 			Success: false,
 			URL:     input.URL,
@@ -103,7 +103,7 @@ func executeWebFetch(ctx context.Context, input WebFetchInput) (*WebFetchOutput,
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		slog.Error("http.DefaultClient.Do() error", "url", input.URL, "err", err)
+		slog.Error("failed to fetch web page", "url", input.URL, "err", err)
 		return &WebFetchOutput{
 			Success: false,
 			URL:     input.URL,
@@ -125,7 +125,7 @@ func executeWebFetch(ctx context.Context, input WebFetchInput) (*WebFetchOutput,
 	// 5. 使用 go-readability v2 解析
 	article, err := readability.FromReader(resp.Body, parsedURL)
 	if err != nil {
-		slog.Error("readability.FromReader() error", "url", input.URL, "err", err)
+		slog.Error("failed to parse web page content", "url", input.URL, "err", err)
 		return &WebFetchOutput{
 			Success: false,
 			URL:     input.URL,

--- a/internal/pkg/tools/websearch.go
+++ b/internal/pkg/tools/websearch.go
@@ -153,7 +153,7 @@ func searchSearXNG(ctx context.Context, instanceURL, query string, numResults in
 	// 创建 HTTP 请求
 	req, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
 	if err != nil {
-		slog.Error("http.NewRequestWithContext() error", "url", fullURL, "err", err)
+		slog.Error("failed to create web search request", "url", fullURL, "err", err)
 		return nil, fmt.Errorf("创建请求失败: %w", err)
 	}
 
@@ -163,7 +163,7 @@ func searchSearXNG(ctx context.Context, instanceURL, query string, numResults in
 	// 发送请求
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		slog.Error("http.DefaultClient.Do() error", "url", fullURL, "err", err)
+		slog.Error("failed to send web search request", "url", fullURL, "err", err)
 		return nil, fmt.Errorf("请求失败: %w", err)
 	}
 	defer resp.Body.Close()
@@ -171,7 +171,7 @@ func searchSearXNG(ctx context.Context, instanceURL, query string, numResults in
 	// 读取响应
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		slog.Error("io.ReadAll() error", "err", err)
+		slog.Error("failed to read web search response", "err", err)
 		return nil, fmt.Errorf("读取响应失败: %w", err)
 	}
 
@@ -184,7 +184,7 @@ func searchSearXNG(ctx context.Context, instanceURL, query string, numResults in
 	// 解析 JSON 响应
 	var searxResp SearXNGResponse
 	if err := json.Unmarshal(body, &searxResp); err != nil {
-		slog.Error("json.Unmarshal() error", "err", err)
+		slog.Error("failed to parse web search response", "err", err)
 		return nil, fmt.Errorf("解析 JSON 失败: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Replace all `slog.Error` messages that used function-name patterns (e.g. `"os.ReadFile() error"`) with descriptive event messages (e.g. `"failed to read config file"`) across 43 Go files
- Update co-located `fmt.Errorf` messages to match the new descriptive style
- Fix minor lint issues: use `maps.Collect`, `fmt.Fprintf`, `strings.SplitSeq`, remove unused params, remove unnecessary loop variable capture
- Update CLAUDE.md logging guidelines with the new convention

## Test plan
- [x] `go build ./...` passes
- [x] No functional logic changes — only string literal updates and minor lint fixes