### PR TITLE
fix: lower VAD start sensitivity to reduce noise false triggers on mobile

### DIFF
--- a/internal/app/aiguide/assistant/live_api.go
+++ b/internal/app/aiguide/assistant/live_api.go
@@ -142,6 +142,12 @@ func (a *Assistant) connectLiveSession(ctx context.Context, userID int, historyC
 				},
 			},
 		},
+		RealtimeInputConfig: &genai.RealtimeInputConfig{
+			AutomaticActivityDetection: &genai.AutomaticActivityDetection{
+				StartOfSpeechSensitivity: genai.StartSensitivityLow,
+				EndOfSpeechSensitivity:   genai.EndSensitivityHigh,
+			},
+		},
 		InputAudioTranscription:  &genai.AudioTranscriptionConfig{},
 		OutputAudioTranscription: &genai.AudioTranscriptionConfig{},
 		SystemInstruction: &genai.Content{


### PR DESCRIPTION
## Summary
- Configure Gemini Live API's `RealtimeInputConfig.AutomaticActivityDetection` with `StartOfSpeechSensitivity: LOW` to reduce false VAD triggers from background noise on mobile devices
- Set `EndOfSpeechSensitivity: HIGH` to maintain responsive turn-end detection

## Test plan
- [ ] Test voice call on mobile in noisy environment, verify no phantom "user speaking" indicators
- [ ] Test voice call on desktop, verify normal speech is still detected correctly
- [ ] Verify turn-end detection remains responsive (no long pauses before AI responds)