### PR TITLE
fix: defer audio capture until Gemini Live session is ready

### DIFF
--- a/frontend/app/chat/[sessionId]/components/ChatInput.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatInput.tsx
@@ -30,6 +30,7 @@ interface ChatInputProps {
   onVoiceToggle?: () => void;
   voiceError?: string | null;
   isVoiceCallActive?: boolean;
+  isVoiceCallConnecting?: boolean;
   onVoiceCallToggle?: () => void;
   voiceCallError?: string | null;
 }
@@ -59,6 +60,7 @@ const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(({
   onVoiceToggle,
   voiceError,
   isVoiceCallActive = false,
+  isVoiceCallConnecting = false,
   onVoiceCallToggle,
   voiceCallError,
 }, textareaRef) => {
@@ -190,9 +192,11 @@ const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(({
                 disabled={isLoading || isLoadingHistory}
                 className={cn(
                   "h-8 w-8 sm:h-7 sm:w-7 rounded-full transition-all duration-200",
-                  isVoiceCallActive
-                    ? "bg-green-500 text-white hover:bg-green-600 shadow-md"
-                    : "text-muted-foreground hover:text-foreground"
+                  isVoiceCallConnecting
+                    ? "bg-green-500/60 text-white animate-pulse shadow-md"
+                    : isVoiceCallActive
+                      ? "bg-green-500 text-white hover:bg-green-600 shadow-md"
+                      : "text-muted-foreground hover:text-foreground"
                 )}
                 title={isVoiceCallActive ? "结束语音通话" : "语音通话"}
                 aria-label={isVoiceCallActive ? "结束语音通话" : "语音通话"}

--- a/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
@@ -257,6 +257,7 @@ export function ChatPageLayout({
     onVoiceToggle,
     voiceError,
     isVoiceCallActive,
+    isVoiceCallConnecting: voiceCallStatus === 'connecting',
     onVoiceCallToggle,
     voiceCallError,
   };
@@ -322,9 +323,14 @@ export function ChatPageLayout({
                 </div>
               </div>
             </div>
-            {(voiceCallStatus === 'connected' || voiceCallError) && (
+            {(voiceCallStatus === 'connecting' || voiceCallStatus === 'connected' || voiceCallError) && (
               <div className="w-full md:pl-[260px] flex justify-center px-3 sm:px-4 md:px-6">
-                {voiceCallStatus === 'connected' ? (
+                {voiceCallStatus === 'connecting' ? (
+                  <div className="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+                    <span className="w-2 h-2 rounded-full bg-yellow-500 animate-pulse" />
+                    <span>Connecting...</span>
+                  </div>
+                ) : voiceCallStatus === 'connected' ? (
                   <div className="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
                     <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
                     <span>Stream is live</span>

--- a/frontend/app/chat/[sessionId]/hooks/useVoiceCall.ts
+++ b/frontend/app/chat/[sessionId]/hooks/useVoiceCall.ts
@@ -332,6 +332,7 @@ export function useVoiceCall(sessionId?: string): UseVoiceCallResult {
 
     switch (msg.type) {
       case 'setup_ok':
+        startCapture(stream, ws);
         setStatus('connected');
         break;
 
@@ -426,7 +427,7 @@ export function useVoiceCall(sessionId?: string): UseVoiceCallResult {
 
     ws.onmessage = (ev) => handleWsMessage(ev, stream, ws);
 
-    ws.onopen = () => startCapture(stream, ws);
+    ws.onopen = () => {};
 
     ws.onerror = () => {
       setError('WebSocket connection error');


### PR DESCRIPTION
## Summary
- Moved `startCapture()` from `ws.onopen` to `setup_ok` message handler so audio only streams after the full pipeline (WebSocket + Gemini Live session) is established
- Added "Connecting..." indicator with yellow pulse dot while the backend connects to Gemini Live
- Phone button now shows a pulsing semi-transparent green during `connecting` state, solid green only when fully `connected`

## Root Cause
When the user clicked the call button, `ws.onopen` fired as soon as the TCP handshake completed, immediately starting audio capture. However, the backend was still executing `connectLiveSession()` (connecting to Gemini Live API, ~500ms-2s). Audio sent during this window buffered in TCP and was burst-forwarded to Gemini once ready, confusing the VAD and effectively losing the user's initial speech.

## Test plan
- [ ] Click the phone button — verify it shows pulsing green + "Connecting..." text
- [ ] After ~1-2s it should transition to solid green + "Stream is live"
- [ ] Speak immediately after the button turns solid green — verify speech is captured
- [ ] End the call and verify normal cleanup still works
- [ ] Test on mobile to confirm the connecting state is visible