### PR TITLE
fix: eliminate UI flicker and layout shift when toggling voice call

### DIFF
--- a/frontend/app/chat/ChatPageClient.tsx
+++ b/frontend/app/chat/ChatPageClient.tsx
@@ -127,6 +127,7 @@ export default function ChatPageClient() {
     startCall,
     endCall,
     sendText: voiceCallSendText,
+    clearVoiceMessages,
     error: voiceCallError,
   } = useVoiceCall(sessionId);
 
@@ -145,9 +146,11 @@ export default function ChatPageClient() {
     const prev = prevVoiceCallStatusRef.current;
     prevVoiceCallStatusRef.current = voiceCallStatus;
     if (prev === 'connected' && voiceCallStatus === 'idle' && sessionId) {
-      loadSessionHistory(sessionId, true);
+      loadSessionHistory(sessionId, true).then(() => {
+        clearVoiceMessages();
+      });
     }
-  }, [voiceCallStatus, sessionId, loadSessionHistory]);
+  }, [voiceCallStatus, sessionId, loadSessionHistory, clearVoiceMessages]);
 
   const handleVoiceCallToggle = useCallback(() => {
     if (isVoiceCallActive) {

--- a/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
@@ -324,7 +324,7 @@ export function ChatPageLayout({
               </div>
             </div>
             {(voiceCallStatus === 'connecting' || voiceCallStatus === 'connected' || voiceCallError) && (
-              <div className="w-full md:pl-[260px] flex justify-center px-3 sm:px-4 md:px-6">
+              <div className="absolute bottom-12 left-0 w-full md:pl-[260px] flex justify-center z-10">
                 {voiceCallStatus === 'connecting' ? (
                   <div className="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
                     <span className="w-2 h-2 rounded-full bg-yellow-500 animate-pulse" />

--- a/frontend/app/chat/[sessionId]/hooks/useSessionHistory.ts
+++ b/frontend/app/chat/[sessionId]/hooks/useSessionHistory.ts
@@ -70,16 +70,23 @@ export function useSessionHistory({
     autoLoadedSessionIdRef.current = targetSessionId;
     const requestId = ++historyRequestIdRef.current;
 
-    if (updateUrl && targetSessionId !== sessionId) {
+    const isSameSession = targetSessionId === sessionId;
+
+    if (updateUrl && !isSameSession) {
       pendingSessionIdRef.current = targetSessionId;
       window.history.pushState(null, '', getChatPath(targetSessionId));
       setSessionId(targetSessionId);
+      resetSessionView(true);
     } else {
       pendingSessionIdRef.current = null;
+      if (!isSameSession) {
+        resetSessionView(true);
+      }
     }
 
-    resetSessionView(true);
-    setIsLoadingHistory(true);
+    if (!isSameSession) {
+      setIsLoadingHistory(true);
+    }
 
     try {
       const response = await authenticatedFetch(
@@ -106,10 +113,12 @@ export function useSessionHistory({
       }
 
       setIsLoadingHistory(false);
-      scrollResetTimeoutRef.current = setTimeout(() => {
-        setShouldScrollInstantly(false);
-        scrollResetTimeoutRef.current = null;
-      }, SCROLL_RESET_DELAY);
+      if (!isSameSession) {
+        scrollResetTimeoutRef.current = setTimeout(() => {
+          setShouldScrollInstantly(false);
+          scrollResetTimeoutRef.current = null;
+        }, SCROLL_RESET_DELAY);
+      }
     }
   }, [agentId, authenticatedFetch, resetSessionView, sessionId, setSessionId, userId]);
 

--- a/frontend/app/chat/[sessionId]/hooks/useVoiceCall.ts
+++ b/frontend/app/chat/[sessionId]/hooks/useVoiceCall.ts
@@ -19,6 +19,7 @@ interface UseVoiceCallResult {
   startCall: (overrideSessionId?: string) => Promise<void>;
   endCall: () => void;
   sendText: (text: string, images?: string[]) => void;
+  clearVoiceMessages: () => void;
   error: string | null;
 }
 
@@ -130,6 +131,59 @@ export function useVoiceCall(sessionId?: string): UseVoiceCallResult {
   const isToolCallActiveRef = useRef(false);
   const toolCallTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const connectingAudioCtxRef = useRef<AudioContext | null>(null);
+  const isConnectingSoundActiveRef = useRef(false);
+  const connectingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const startConnectingSound = useCallback(() => {
+    if (isConnectingSoundActiveRef.current) return;
+    const ctx = new AudioContext();
+    connectingAudioCtxRef.current = ctx;
+    isConnectingSoundActiveRef.current = true;
+
+    const notes = [392, 440, 494, 440];
+    const noteDuration = 0.35;
+    const noteGap = 0.4;
+    const totalDuration = notes.length * noteGap;
+    const loopGap = 0.5;
+
+    const playLoop = () => {
+      if (!isConnectingSoundActiveRef.current) return;
+      const now = ctx.currentTime;
+      notes.forEach((freq, i) => {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(freq, 0);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        const start = now + i * noteGap;
+        gain.gain.setValueAtTime(0, start);
+        gain.gain.linearRampToValueAtTime(0.12, start + 0.05);
+        gain.gain.setValueAtTime(0.12, start + noteDuration * 0.6);
+        gain.gain.exponentialRampToValueAtTime(0.001, start + noteDuration);
+        osc.start(start);
+        osc.stop(start + noteDuration);
+      });
+      connectingTimerRef.current = setTimeout(() => {
+        connectingTimerRef.current = null;
+        playLoop();
+      }, (totalDuration + loopGap) * 1000);
+    };
+
+    playLoop();
+  }, []);
+
+  const stopConnectingSound = useCallback(() => {
+    isConnectingSoundActiveRef.current = false;
+    if (connectingTimerRef.current !== null) {
+      clearTimeout(connectingTimerRef.current);
+      connectingTimerRef.current = null;
+    }
+    connectingAudioCtxRef.current?.close();
+    connectingAudioCtxRef.current = null;
+  }, []);
+
   const startToolCallSound = useCallback(() => {
     if (isToolCallActiveRef.current) return;
     const ctx = new AudioContext();
@@ -215,6 +269,7 @@ export function useVoiceCall(sessionId?: string): UseVoiceCallResult {
     nextPlayTimeRef.current = 0;
 
     stopToolCallSound();
+    stopConnectingSound();
 
     turnPhaseRef.current = 'waiting';
     userAudioChunksRef.current = [];
@@ -222,9 +277,8 @@ export function useVoiceCall(sessionId?: string): UseVoiceCallResult {
     currentUserMsgIdRef.current = null;
     currentModelMsgIdRef.current = null;
 
-    setVoiceMessages([]);
     setStatus('idle');
-  }, [stopToolCallSound]);
+  }, [stopToolCallSound, stopConnectingSound]);
 
   useEffect(() => () => cleanup(), [cleanup]);
 
@@ -332,6 +386,7 @@ export function useVoiceCall(sessionId?: string): UseVoiceCallResult {
 
     switch (msg.type) {
       case 'setup_ok':
+        stopConnectingSound();
         startCapture(stream, ws);
         setStatus('connected');
         break;
@@ -394,13 +449,14 @@ export function useVoiceCall(sessionId?: string): UseVoiceCallResult {
         break;
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cleanup, finalizeModelTurn, finalizeUserTurn, playPCMChunk, resetPlayback, startCapture, startToolCallSound, stopToolCallSound]);
+  }, [cleanup, finalizeModelTurn, finalizeUserTurn, playPCMChunk, resetPlayback, startCapture, startToolCallSound, stopConnectingSound, stopToolCallSound]);
 
   const startCall = useCallback(async (overrideSessionId?: string) => {
     if (status !== 'idle') return;
     setError(null);
     setVoiceMessages([]);
     setStatus('connecting');
+    startConnectingSound();
 
     let stream: MediaStream;
     try {
@@ -438,7 +494,7 @@ export function useVoiceCall(sessionId?: string): UseVoiceCallResult {
     ws.onclose = () => {
       cleanup();
     };
-  }, [cleanup, handleWsMessage, sessionId, startCapture, status]);
+  }, [cleanup, handleWsMessage, sessionId, startCapture, startConnectingSound, status]);
 
   const endCall = useCallback(() => {
     if (userAudioChunksRef.current.length > 0 || currentUserMsgIdRef.current) {
@@ -471,7 +527,11 @@ export function useVoiceCall(sessionId?: string): UseVoiceCallResult {
     wsRef.current.send(JSON.stringify(payload));
   }, [finalizeModelTurn, finalizeUserTurn]);
 
-  return { status, voiceMessages, startCall, endCall, sendText, error };
+  const clearVoiceMessages = useCallback(() => {
+    setVoiceMessages([]);
+  }, []);
+
+  return { status, voiceMessages, startCall, endCall, sendText, clearVoiceMessages, error };
 }
 
 function handleInputTranscript(


### PR DESCRIPTION
## Summary
- Fix full-page flash/refresh when exiting voice call by skipping skeleton loading and message clearing during same-session history reload
- Delay clearing voice messages until DB history loads, ensuring seamless visual transition
- Add looping connecting sound during voice call setup so users know when connection is ready
- Fix voice call status bar causing messages to jump by using absolute positioning instead of flow layout

## Test plan
- [ ] Start a voice call → verify connecting sound plays during setup
- [ ] Once connected, verify sound stops and "Stream is live" indicator appears without messages jumping
- [ ] End voice call → verify no page flash/skeleton, messages transition smoothly
- [ ] Verify input box remains centered at bottom throughout