### PR TITLE
fix: use dynamic viewport height to eliminate iOS Safari edge shadows

### DIFF
--- a/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
+++ b/frontend/app/chat/[sessionId]/components/ChatPageLayout.tsx
@@ -263,7 +263,7 @@ export function ChatPageLayout({
   };
 
   return (
-    <div className="flex h-screen bg-background font-sans text-foreground overflow-hidden">
+    <div className="flex h-dvh bg-background font-sans text-foreground overflow-hidden">
       <SessionSidebar
         sessions={sessions}
         projects={projects}


### PR DESCRIPTION
## Summary
- Replace `h-screen` (100vh) with `h-dvh` (100dvh) in the chat page layout container
- On iOS Safari, `100vh` includes the area behind the address bar, causing the browser to render inset shadows at the viewport edges
- `100dvh` dynamically adjusts to the visible area, eliminating the shadow artifacts

## Test plan
- [ ] Open chat page on iOS Safari (iPhone) and verify no shadows at top/bottom edges
- [ ] Verify layout still fills the viewport correctly on desktop browsers
- [ ] Verify address bar show/hide transitions work smoothly on mobile